### PR TITLE
APIM v2 SKUs Support

### DIFF
--- a/infra/modules/apim/apim.bicep
+++ b/infra/modules/apim/apim.bicep
@@ -8,7 +8,9 @@ param publisherEmail string = 'noreply@microsoft.com'
 
 @minLength(1)
 param publisherName string = 'n/a'
+
 param sku string = 'Developer'
+var isV2SKU = sku == 'StandardV2' || sku == 'PremiumV2'
 param skuCount int = 1
 param applicationInsightsName string
 param openAiUris array
@@ -41,6 +43,15 @@ param aiLanguageServiceUrl string
 param apimNetworkType string = 'External'
 param apimSubnetId string
 
+param apimV2PrivateDnsZoneName string = 'privatelink.azure-api.net'
+param apimV2PrivateEndpointName string
+param dnsZoneRG string = resourceGroup().name
+param dnsSubscriptionId string = subscription().subscriptionId
+param privateEndpointSubnetId string
+param usePrivateEndpoint bool = false
+param apimV2PublicNetworkAccess bool = true
+var apimPublicNetworkAccess = apimV2PublicNetworkAccess ? 'Enabled' : 'Disabled'
+
 var openAiApiBackendId = 'openai-backend'
 var openAiApiUamiNamedValue = 'uami-client-id'
 var openAiApiEntraNamedValue = 'entra-auth'
@@ -49,6 +60,7 @@ var openAiApiTenantNamedValue = 'tenant-id'
 var openAiApiAudienceNamedValue = 'audience'
 
 var apiManagementMinApiVersion = '2021-08-01'
+var apiManagementMinApiVersionV2 = '2024-05-01'
 
 // Add this variable near the top with other variables
 // var apimZones = sku == 'Premium' && skuCount > 1 ? ['1','2','3'] : []
@@ -79,7 +91,7 @@ resource eventHubPII 'Microsoft.EventHub/namespaces/eventhubs@2023-01-01-preview
 //   name: aiLanguageServiceName
 // }
 
-resource apimService 'Microsoft.ApiManagement/service@2021-08-01' = {
+resource apimService 'Microsoft.ApiManagement/service@2024-05-01' = {
   name: name
   location: location
   tags: union(tags, { 'azd-service-name': name })
@@ -96,12 +108,13 @@ resource apimService 'Microsoft.ApiManagement/service@2021-08-01' = {
   properties: {
     publisherEmail: publisherEmail
     publisherName: publisherName
-    virtualNetworkType: apimNetworkType
-    virtualNetworkConfiguration: apimNetworkType != 'None' ? {
+    virtualNetworkType: isV2SKU ? 'External' : apimNetworkType
+    publicNetworkAccess: isV2SKU ? apimPublicNetworkAccess : 'Enabled'
+    virtualNetworkConfiguration: apimNetworkType != 'None' || isV2SKU ? {
       subnetResourceId: apimSubnetId
     } : null
     apiVersionConstraint: {
-      minApiVersion: apiManagementMinApiVersion
+      minApiVersion: isV2SKU? apiManagementMinApiVersionV2 : apiManagementMinApiVersion
     }
     // Custom properties are not supported for Consumption SKU
     customProperties: sku == 'Consumption' ? {} : {
@@ -122,6 +135,22 @@ resource apimService 'Microsoft.ApiManagement/service@2021-08-01' = {
     }
   }
   zones: apimZones
+}
+
+module privateEndpoint '../networking/private-endpoint.bicep' = if (isV2SKU && usePrivateEndpoint) {
+  name: '${name}-privateEndpoint'
+  params: {
+    groupIds: [
+      'Gateway'
+    ]
+    dnsZoneName: apimV2PrivateDnsZoneName
+    name: apimV2PrivateEndpointName
+    privateLinkServiceId: apimService.id
+    location: location
+    dnsZoneRG: dnsZoneRG
+    privateEndpointSubnetId: privateEndpointSubnetId
+    dnsSubId: dnsSubscriptionId
+  }
 }
 
 module apimOpenaiApi './api.bicep' = {
@@ -242,6 +271,12 @@ module apimOpenAIRealTimetApi './api.bicep' = if (enableOpenAIRealtime) {
     apiProtocols: ['wss']
   }
   dependsOn: [
+    aadAuthPolicyFragment
+    validateRoutesPolicyFragment
+    backendRoutingPolicyFragment
+    openAIUsagePolicyFragment
+    openAIUsageStreamingPolicyFragment
+    openAiBackends
   ]
 }
 

--- a/infra/modules/networking/vnet.bicep
+++ b/infra/modules/networking/vnet.bicep
@@ -12,6 +12,7 @@ param vnetAddressPrefix string
 param apimSubnetAddressPrefix string
 param privateEndpointSubnetAddressPrefix string
 param functionAppSubnetAddressPrefix string
+param isAPIMV2SKU bool
 param tags object = {}
 
 // Set to true to enable service endpoints for APIM subnet
@@ -207,6 +208,16 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2019-11-01' = {
             {
               service: 'Microsoft.Storage'
             }
+          ] : []
+          privateEndpointNetworkPolicies: 'Enabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+          delegations: isAPIMV2SKU ? [
+          {
+            name: 'Microsoft.Web/serverFarms'
+            properties: {
+            serviceName: 'Microsoft.Web/serverFarms'
+            }
+          }
           ] : []
         }
       }


### PR DESCRIPTION
This pull request introduces support for API Management V2 SKUs (`StandardV2` and `PremiumV2`) in the Azure infrastructure provisioning templates (`infra/main.bicep` and related module files). The changes primarily focus on adding parameters, variables, and configurations necessary for these new SKUs, including private endpoint support and updated API versions.

### Support for API Management V2 SKUs:

* **New Parameters and Variables**:
  - Added parameters like `apimV2PrivateEndpointName`, `apimV2UsePrivateEndpoint`, and `apimV2PublicNetworkAccess` for configuring private endpoints and public network access for API Management V2 SKUs. (`[[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R152-R166)`, `[[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L641-R658)`)
  - Introduced variables such as `apimV2SkuDnsZoneName` and `apiManagementMinApiVersionV2` for DNS zone configuration and minimum API version requirements for V2 SKUs. (`[[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R392)`, `[[2]](diffhunk://#diff-6d8d8ed65a3f17737cc27a78b35bf2c6c3ea838ad3515020db20b21897d11d4aR63)`)

* **Template Updates for V2 SKU Logic**:
  - Updated logic in `infra/main.bicep` and `infra/modules/apim/apim.bicep` to differentiate between V2 and non-V2 SKUs, including conditional handling of virtual network configurations and private endpoints. (`[[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R436)`, `[[2]](diffhunk://#diff-6d8d8ed65a3f17737cc27a78b35bf2c6c3ea838ad3515020db20b21897d11d4aL99-R117)`)
  - Added support for delegations in the virtual network configuration for V2 SKUs in `infra/modules/networking/vnet.bicep`. (`[infra/modules/networking/vnet.bicepR212-R221](diffhunk://#diff-ee74f2a712a8be76233faab40e9c84f2d7c9e4c23c7fae91deb05aab00cfd300R212-R221)`)

### Private Endpoint Support:

* **Private Endpoint Module Integration**:
  - Integrated a private endpoint module for V2 SKUs, enabling private link service configurations with parameters like `dnsZoneName` and `privateLinkServiceId`. (`[infra/modules/apim/apim.bicepR140-R155](diffhunk://#diff-6d8d8ed65a3f17737cc27a78b35bf2c6c3ea838ad3515020db20b21897d11d4aR140-R155)`)
  - Configured private endpoint network policies and delegations for V2 SKUs in the virtual network module. (`[infra/modules/networking/vnet.bicepR212-R221](diffhunk://#diff-ee74f2a712a8be76233faab40e9c84f2d7c9e4c23c7fae91deb05aab00cfd300R212-R221)`)

### API Version and Dependencies:

* **Updated API Versions**:
  - Changed the API version for `Microsoft.ApiManagement/service` to `2024-05-01` for V2 SKUs. (`[infra/modules/apim/apim.bicepL82-R94](diffhunk://#diff-6d8d8ed65a3f17737cc27a78b35bf2c6c3ea838ad3515020db20b21897d11d4aL82-R94)`)
  - Applied conditional logic to use the appropriate minimum API version based on SKU type. (`[infra/modules/apim/apim.bicepL99-R117](diffhunk://#diff-6d8d8ed65a3f17737cc27a78b35bf2c6c3ea838ad3515020db20b21897d11d4aL99-R117)`)

* **Dependency Adjustments**:
  - Added dependencies for policy fragments and backend routing in the `apimOpenAIRealtimeApi` module to ensure proper configuration for V2 SKUs. (`[infra/modules/apim/apim.bicepR274-R279](diffhunk://#diff-6d8d8ed65a3f17737cc27a78b35bf2c6c3ea838ad3515020db20b21897d11d4aR274-R279)`)