### PR TITLE
Improved client on-boarding automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -413,3 +413,4 @@ local/**/*
 **/package-lock.json
 **/.vscode
 **/*.local.parameters.json
+infra/usecase-onboarding/samples/financial-assistant-usecase-local.sh

--- a/infra/usecase-onboarding/README.md
+++ b/infra/usecase-onboarding/README.md
@@ -170,7 +170,6 @@ pie title Services onboarded
 
 Where to start
 - Parameters file (generic placeholders): `infra/usecase-onboarding/samples/financial-assist-usecase.parameters.json`
-- Parameters file (local sample): `infra/usecase-onboarding/samples/financial-assist-usecase.local.parameters.json`
 
 Key fields (excerpt)
 - `useCase`: `{ businessUnit: "Retail", useCaseName: "FinancialAssistant", environment: "DEV" }`

--- a/infra/usecase-onboarding/main.json
+++ b/infra/usecase-onboarding/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.37.4.10188",
-      "templateHash": "18277901564264477872"
+      "templateHash": "1626768243939706846"
     }
   },
   "parameters": {
@@ -37,7 +37,7 @@
     "services": {
       "type": "array",
       "metadata": {
-        "description": "Required AI services for this use case. Each item: { code: \"OAI\", endpointSecretName: \"OAI_ENDPOINT\", apiKeySecretName: \"OAI_KEY\", policyXml: \"<policies>...</policies>\" }"
+        "description": "Required AI services for this use case. Each item: { code: \"OAI\", endpointSecretName: \"OAI_ENDPOINT\", apiKeySecretName: \"OAI_KEY\", policyXml?: \"<policies>...</policies>\" }. If omitted or empty, the default policy at policies/default-ai-product-policy.xml is used."
       }
     },
     "productTerms": {
@@ -49,14 +49,8 @@
     }
   },
   "variables": {
-    "copy": [
-      {
-        "name": "normalizedServices",
-        "count": "[length(parameters('services'))]",
-        "input": "[union(createObject('policyXml', ''), parameters('services')[copyIndex('normalizedServices')])]"
-      }
-    ],
-    "productPostfix": "[format('{0}-{1}-{2}', parameters('useCase').businessUnit, parameters('useCase').useCaseName, parameters('useCase').environment)]"
+    "productPostfix": "[format('{0}-{1}-{2}', parameters('useCase').businessUnit, parameters('useCase').useCaseName, parameters('useCase').environment)]",
+    "defaultProductPolicyXml": "<policies>\r\n  <inbound>\r\n    <base />\r\n    <!-- Basic rate limit per subscription as a safeguard -->\r\n    <rate-limit calls=\"100\" renewal-period=\"60\" />\r\n  </inbound>\r\n  <backend>\r\n    <base />\r\n  </backend>\r\n  <outbound>\r\n    <base />\r\n  </outbound>\r\n  <on-error>\r\n    <base />\r\n  </on-error>\r\n</policies>\r\n"
   },
   "resources": {
     "apimRg": {
@@ -92,11 +86,11 @@
     "onboard": {
       "copy": {
         "name": "onboard",
-        "count": "[length(variables('normalizedServices'))]"
+        "count": "[length(parameters('services'))]"
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('onboard-{0}-{1}', variables('normalizedServices')[copyIndex()].code, variables('productPostfix'))]",
+      "name": "[format('onboard-{0}-{1}', parameters('services')[copyIndex()].code, variables('productPostfix'))]",
       "subscriptionId": "[parameters('apim').subscriptionId]",
       "resourceGroup": "[parameters('apim').resourceGroupName]",
       "properties": {
@@ -109,28 +103,26 @@
             "value": "[parameters('apim').name]"
           },
           "productId": {
-            "value": "[format('{0}-{1}', variables('normalizedServices')[copyIndex()].code, variables('productPostfix'))]"
+            "value": "[format('{0}-{1}', parameters('services')[copyIndex()].code, variables('productPostfix'))]"
           },
           "productDisplayName": {
-            "value": "[format('{0} {1} {2} {3}', variables('normalizedServices')[copyIndex()].code, parameters('useCase').businessUnit, parameters('useCase').useCaseName, parameters('useCase').environment)]"
+            "value": "[format('{0} {1} {2} {3}', parameters('services')[copyIndex()].code, parameters('useCase').businessUnit, parameters('useCase').useCaseName, parameters('useCase').environment)]"
           },
           "productDescription": {
-            "value": "[format('AI Gateway product for {0} - {1}', variables('normalizedServices')[copyIndex()].code, parameters('useCase').useCaseName)]"
+            "value": "[format('AI Gateway product for {0} - {1}', parameters('services')[copyIndex()].code, parameters('useCase').useCaseName)]"
           },
           "productTerms": {
             "value": "[parameters('productTerms')]"
           },
           "apiResourceIds": {
-            "value": "[parameters('existingServices')[variables('normalizedServices')[copyIndex()].code].apiResourceIds]"
+            "value": "[parameters('existingServices')[parameters('services')[copyIndex()].code].apiResourceIds]"
           },
-          "productPolicyXml": {
-            "value": "[variables('normalizedServices')[copyIndex()].policyXml]"
-          },
+          "productPolicyXml": "[if(equals(parameters('services')[copyIndex()].policyXml, ''), createObject('value', variables('defaultProductPolicyXml')), createObject('value', parameters('services')[copyIndex()].policyXml))]",
           "subscriptionName": {
-            "value": "[format('{0}-{1}-SUB-01', variables('normalizedServices')[copyIndex()].code, variables('productPostfix'))]"
+            "value": "[format('{0}-{1}-SUB-01', parameters('services')[copyIndex()].code, variables('productPostfix'))]"
           },
           "subscriptionDisplayName": {
-            "value": "[format('{0}-{1}-SUB-01', variables('normalizedServices')[copyIndex()].code, variables('productPostfix'))]"
+            "value": "[format('{0}-{1}-SUB-01', parameters('services')[copyIndex()].code, variables('productPostfix'))]"
           }
         },
         "template": {
@@ -141,7 +133,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9071235648865231712"
+              "templateHash": "9229402873619434252"
             }
           },
           "parameters": {
@@ -223,8 +215,8 @@
                 "description": "[parameters('productDescription')]",
                 "terms": "[parameters('productTerms')]",
                 "subscriptionRequired": true,
-                "approvalRequired": true,
-                "subscriptionsLimit": -1,
+                "approvalRequired": false,
+                "subscriptionsLimit": 10,
                 "state": "published"
               }
             },
@@ -258,9 +250,12 @@
               "name": "[format('{0}/{1}', parameters('apimName'), parameters('subscriptionName'))]",
               "properties": {
                 "displayName": "[parameters('subscriptionDisplayName')]",
-                "scope": "[format('/products/{0}', parameters('productId'))]",
+                "scope": "[resourceId('Microsoft.ApiManagement/service/products', parameters('apimName'), parameters('productId'))]",
                 "state": "active"
-              }
+              },
+              "dependsOn": [
+                "product"
+              ]
             },
             "api": {
               "existing": true,
@@ -293,11 +288,11 @@
     "kvWrites": {
       "copy": {
         "name": "kvWrites",
-        "count": "[length(variables('normalizedServices'))]"
+        "count": "[length(parameters('services'))]"
       },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2022-09-01",
-      "name": "[format('kv-{0}-{1}', variables('normalizedServices')[copyIndex()].code, variables('productPostfix'))]",
+      "name": "[format('kv-{0}-{1}', parameters('services')[copyIndex()].code, variables('productPostfix'))]",
       "subscriptionId": "[parameters('keyVault').subscriptionId]",
       "resourceGroup": "[parameters('keyVault').resourceGroupName]",
       "properties": {
@@ -311,14 +306,14 @@
           },
           "secretNames": {
             "value": [
-              "[variables('normalizedServices')[copyIndex()].endpointSecretName]",
-              "[variables('normalizedServices')[copyIndex()].apiKeySecretName]"
+              "[toLower(replace(parameters('services')[copyIndex()].endpointSecretName, '_', '-'))]",
+              "[toLower(replace(parameters('services')[copyIndex()].apiKeySecretName, '_', '-'))]"
             ]
           },
           "secretValues": {
             "value": {
-              "[format('{0}', variables('normalizedServices')[copyIndex()].endpointSecretName)]": "[format('{0}/{1}', reference('apimSvc').gatewayUrl, reference(format('onboard[{0}]', copyIndex())).outputs.apiPath.value)]",
-              "[format('{0}', variables('normalizedServices')[copyIndex()].apiKeySecretName)]": "[listOutputsWithSecureValues(format('onboard[{0}]', copyIndex()), '2022-09-01').subscriptionPrimaryKey]"
+              "[format('{0}', toLower(replace(parameters('services')[copyIndex()].endpointSecretName, '_', '-')))]": "[format('{0}/{1}', reference('apimSvc').gatewayUrl, reference(format('onboard[{0}]', copyIndex())).outputs.apiPath.value)]",
+              "[format('{0}', toLower(replace(parameters('services')[copyIndex()].apiKeySecretName, '_', '-')))]": "[listOutputsWithSecureValues(format('onboard[{0}]', copyIndex()), '2022-09-01').subscriptionPrimaryKey]"
             }
           }
         },
@@ -329,7 +324,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.37.4.10188",
-              "templateHash": "9432321189899560493"
+              "templateHash": "16580792813839761015"
             }
           },
           "parameters": {
@@ -363,7 +358,7 @@
               "name": "[format('{0}/{1}', parameters('keyVaultName'), parameters('secretNames')[copyIndex()])]",
               "properties": {
                 "value": "[parameters('secretValues')[parameters('secretNames')[copyIndex()]]]",
-                "contentType": "text/plain"
+                "contentType": "string"
               }
             }
           ],
@@ -404,8 +399,8 @@
         "input": {
           "name": "[format('{0}-{1}-SUB-01', parameters('services')[copyIndex()].code, variables('productPostfix'))]",
           "productId": "[format('{0}-{1}', parameters('services')[copyIndex()].code, variables('productPostfix'))]",
-          "keyVaultApiKeySecretName": "[parameters('services')[copyIndex()].apiKeySecretName]",
-          "keyVaultEndpointSecretName": "[parameters('services')[copyIndex()].endpointSecretName]"
+          "keyVaultApiKeySecretName": "[toLower(replace(parameters('services')[copyIndex()].apiKeySecretName, '_', '-'))]",
+          "keyVaultEndpointSecretName": "[toLower(replace(parameters('services')[copyIndex()].endpointSecretName, '_', '-'))]"
         }
       }
     }

--- a/infra/usecase-onboarding/policies/default-ai-product-policy.xml
+++ b/infra/usecase-onboarding/policies/default-ai-product-policy.xml
@@ -1,23 +1,9 @@
 <policies>
   <inbound>
     <base />
-    <!-- Optional JWT validation -->
-    <!--
-    <validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized">
-      <openid-config url="https://login.microsoftonline.com/{tenant-id}/v2.0/.well-known/openid-configuration" />
-      <required-claims>
-        <claim name="aud">
-          <value>{audience-app-id}</value>
-        </claim>
-      </required-claims>
-    </validate-jwt>
-    -->
-
+    <!-- It is important to review which target AI services will be accessed through this product and adjust accordingly -->
     <!-- Basic rate limit per subscription as a safeguard -->
-    <rate-limit calls="60" renewal-period="60" />
-
-    <!-- Require subscription key -->
-    <check-header name="Ocp-Apim-Subscription-Key" failed-check-httpcode="401" failed-check-error-message="Subscription key required" />
+    <rate-limit calls="100" renewal-period="60" />
   </inbound>
   <backend>
     <base />

--- a/infra/usecase-onboarding/samples/financial-assist-usecase.parameters.json
+++ b/infra/usecase-onboarding/samples/financial-assist-usecase.parameters.json
@@ -38,17 +38,20 @@
         {
           "code": "OAI",
           "endpointSecretName": "OAI-ENDPOINT",
-          "apiKeySecretName": "OAI-KEY"
+          "apiKeySecretName": "OAI-KEY",
+          "policyXml": ""
         },
         {
           "code": "DOC",
           "endpointSecretName": "DOC-ENDPOINT",
-          "apiKeySecretName": "DOC-KEY"
+          "apiKeySecretName": "DOC-KEY",
+          "policyXml": ""
         },
         {
           "code": "OAIRT",
           "endpointSecretName": "OAIRT-ENDPOINT",
-          "apiKeySecretName": "OAIRT-KEY"
+          "apiKeySecretName": "OAIRT-KEY",
+          "policyXml": ""
         }
       ]
     },

--- a/infra/usecase-onboarding/samples/usecase.parameters.json
+++ b/infra/usecase-onboarding/samples/usecase.parameters.json
@@ -38,12 +38,14 @@
         {
           "code": "OAI",
           "endpointSecretName": "AzureOpenAI-Endpoint",
-          "apiKeySecretName": "AzureOpenAI-Key"
+          "apiKeySecretName": "AzureOpenAI-Key",
+          "policyXml": ""
         },
         {
           "code": "DOC",
           "endpointSecretName": "AzureDocumentIntelligence-Endpoint",
-          "apiKeySecretName": "AzureDocumentIntelligence-Key"
+          "apiKeySecretName": "AzureDocumentIntelligence-Key",
+          "policyXml": ""
         }
       ]
     },


### PR DESCRIPTION
This pull request refactors the onboarding process for AI services in APIM to simplify how service-specific policies are handled and to improve naming and limits for Key Vault secrets and subscriptions. The most important changes are the removal of the `normalizedServices` variable, direct use of the `services` array, and the introduction of a default policy XML that is applied when no service-specific policy is provided. There are also updates to sample parameter files and improvements to naming conventions and limits.

**Service Policy Handling and Onboarding Logic**
* Removed the `normalizedServices` variable and now directly use the `services` array throughout the Bicep and JSON templates, simplifying the logic and reducing redundancy. [[1]](diffhunk://#diff-c0ccf1a681c1218edfd62c0c8d2a4934d65d5421d2c06bd89f66d0147b500c49L47-R50) [[2]](diffhunk://#diff-c0ccf1a681c1218edfd62c0c8d2a4934d65d5421d2c06bd89f66d0147b500c49L58-R69) [[3]](diffhunk://#diff-c0ccf1a681c1218edfd62c0c8d2a4934d65d5421d2c06bd89f66d0147b500c49L84-R87) [[4]](diffhunk://#diff-880f315368f874e7d40634cfe0bbd13cfdc5bb6b03cafc267324f7cc904f4fbfL95-R93) [[5]](diffhunk://#diff-880f315368f874e7d40634cfe0bbd13cfdc5bb6b03cafc267324f7cc904f4fbfL296-R295)
* Introduced `defaultProductPolicyXml`, which is loaded and applied when a service does not provide a custom `policyXml`. The default policy now enforces a rate limit of 100 calls per 60 seconds and removes the subscription key check and JWT validation by default. [[1]](diffhunk://#diff-c0ccf1a681c1218edfd62c0c8d2a4934d65d5421d2c06bd89f66d0147b500c49L15-R27) [[2]](diffhunk://#diff-8f905ede031c3762a7cc7d1b7f5858bf0067139777dca635380a1791a83bdcddL4-R6) [[3]](diffhunk://#diff-880f315368f874e7d40634cfe0bbd13cfdc5bb6b03cafc267324f7cc904f4fbfL52-R53) [[4]](diffhunk://#diff-880f315368f874e7d40634cfe0bbd13cfdc5bb6b03cafc267324f7cc904f4fbfL112-R125)

**Parameter and Output Updates**
* Updated sample parameter files (`financial-assist-usecase.parameters.json`, `usecase.parameters.json`) to explicitly include an empty `policyXml` for each service, ensuring the default policy is applied unless overridden. [[1]](diffhunk://#diff-a78d3e5dd5bf8d33446ac8733af177239ba1653bf17e178b00173c538a7ac688L41-R54) [[2]](diffhunk://#diff-ef7765a8cf5d762ca82adc6b9cb1e20f8218226116e951102cc2a5ade209c15dL41-R48)

**Key Vault Secret Naming and Output**
* Improved Key Vault secret naming by converting underscores to hyphens and lowercasing, ensuring compliance with Key Vault naming rules and consistency in outputs. [[1]](diffhunk://#diff-880f315368f874e7d40634cfe0bbd13cfdc5bb6b03cafc267324f7cc904f4fbfL314-R316) [[2]](diffhunk://#diff-880f315368f874e7d40634cfe0bbd13cfdc5bb6b03cafc267324f7cc904f4fbfL407-R403)

**Subscription and Product Limits**
* Changed APIM product onboarding to set `approvalRequired` to `false` and limit the number of subscriptions to 10, instead of unlimited.
* Updated the subscription resource scope to use a resource ID and added an explicit dependency on the product resource for more reliable deployments.

**Documentation**
* Removed reference to a local sample parameters file from the onboarding README for clarity.