### PR TITLE
fix(infra): Handle models parameterised for deployment to all Foundry instances

### DIFF
--- a/bicep/infra/archive/main.parameters.complete.json
+++ b/bicep/infra/archive/main.parameters.complete.json
@@ -229,6 +229,9 @@
     "enableAPICenter": {
       "value": true
     },
+    "apicLocation": {
+      "value": ""
+    },
     "// COMPUTE SKU & SIZE": {
       "value": "SKUs and capacity settings"
     },
@@ -290,6 +293,13 @@
     "aiFoundryModelsConfig": {
       "value": [
         {
+          "name": "DeepSeek-R1",
+          "publisher": "DeepSeek",
+          "version": "1",
+          "sku": "GlobalStandard",
+          "capacity": 1
+        },
+        {
           "name": "gpt-4o-mini",
           "publisher": "OpenAI",
           "version": "2024-07-18",
@@ -306,14 +316,6 @@
           "aiserviceIndex": 0
         },
         {
-          "name": "DeepSeek-R1",
-          "publisher": "DeepSeek",
-          "version": "1",
-          "sku": "GlobalStandard",
-          "capacity": 1,
-          "aiserviceIndex": 0
-        },
-        {
           "name": "Phi-4",
           "publisher": "Microsoft",
           "version": "3",
@@ -327,14 +329,6 @@
           "version": "2025-08-07",
           "sku": "GlobalStandard",
           "capacity": 100,
-          "aiserviceIndex": 1
-        },
-        {
-          "name": "DeepSeek-R1",
-          "publisher": "DeepSeek",
-          "version": "1",
-          "sku": "GlobalStandard",
-          "capacity": 1,
           "aiserviceIndex": 1
         }
       ]

--- a/bicep/infra/main.bicep
+++ b/bicep/infra/main.bicep
@@ -237,6 +237,10 @@ param entraAuth bool = false
 @description('Enable API Center for API governance and discovery.')
 param enableAPICenter bool = true
 
+@description('Location of the API Center service. Leave blank to use primary location, where API Center is available in that region.')
+@allowed(['', 'australiaeast', 'canadacentral', 'centralindia', 'eastus', 'francecentral', 'swedencentral', 'uksouth', 'westeurope' ])
+param apicLocation string = ''
+
 //
 // COMPUTE SKU & SIZE - SKUs and capacity settings for services
 //
@@ -791,7 +795,7 @@ module apiCenter './modules/apic/apic.bicep' = if(enableAPICenter) {
   params: {
     apicServiceName: !empty(apicServiceName) ? apicServiceName : '${abbrs.apiCenterService}${resourceToken}'
     apicsku: apicSku
-    location: 'swedencentral'
+    location: !empty(apicLocation) ? apicLocation : location
     tags: tags
   }
 }

--- a/bicep/infra/main.parameters.complete.bicepparam
+++ b/bicep/infra/main.parameters.complete.bicepparam
@@ -138,6 +138,7 @@ param enableOpenAIRealtime = true
 param enableAIFoundry = true
 param entraAuth = false
 param enableAPICenter = true
+param apicLocation = '' // blank to use param location
 
 // =============================================================================
 // COMPUTE SKU & SIZE
@@ -198,7 +199,15 @@ param aiFoundryInstances = [
 // aiserviceIndex: Index of the AI Foundry instance in aiFoundryInstances array
 // Leave aiserviceIndex empty to deploy to all instances
 param aiFoundryModelsConfig = [
-  // Models for AI Foundry Instance 0
+  // Models for all AI Foundry instances
+  {
+    name: 'DeepSeek-R1'
+    publisher: 'DeepSeek'
+    version: '1'
+    sku: 'GlobalStandard'
+    capacity: 1
+  }
+  // Models specific to AI Foundry Instance 0
   {
     name: 'gpt-4o-mini'
     publisher: 'OpenAI'
@@ -216,14 +225,6 @@ param aiFoundryModelsConfig = [
     aiserviceIndex: 0
   }
   {
-    name: 'DeepSeek-R1'
-    publisher: 'DeepSeek'
-    version: '1'
-    sku: 'GlobalStandard'
-    capacity: 1
-    aiserviceIndex: 0
-  }
-  {
     name: 'Phi-4'
     publisher: 'Microsoft'
     version: '3'
@@ -231,21 +232,13 @@ param aiFoundryModelsConfig = [
     capacity: 1
     aiserviceIndex: 0
   }
-  // Models for AI Foundry Instance 1
+  // Models specific to AI Foundry Instance 1
   {
     name: 'gpt-5'
     publisher: 'OpenAI'
     version: '2025-08-07'
     sku: 'GlobalStandard'
     capacity: 100
-    aiserviceIndex: 1
-  }
-  {
-    name: 'DeepSeek-R1'
-    publisher: 'DeepSeek'
-    version: '1'
-    sku: 'GlobalStandard'
-    capacity: 1
     aiserviceIndex: 1
   }
 ]

--- a/bicep/infra/modules/foundry/foundry.bicep
+++ b/bicep/infra/modules/foundry/foundry.bicep
@@ -175,7 +175,7 @@ module modelDeployments 'deployments.bicep' = [for (config, i) in aiServicesConf
   name: take('models-${foundryResources[i].name}', 64)
   params: {
     cognitiveServiceName: foundryResources[i].name
-    modelsConfig: filter(modelsConfig, model => !contains(model, 'aiservice') || model.aiservice == foundryResources[i].name )
+    modelsConfig: filter(modelsConfig, model => !contains(model, 'aiservice') || empty(model.aiservice) || model.aiservice == foundryResources[i].name)
   }
 }]
 


### PR DESCRIPTION
- Fix: foundry.bicep now recognises `{ aiservice: '' }` for multi-instance deployments, as populated in 
main.bicep's `transformedAiFoundryModelsConfig` when the `aiserviceIndex` parameter is left unspecified.
- New: support regions other than `swedencentral` for API Center.