### PR TITLE
updated llm onboarding policy for authorization

### DIFF
--- a/bicep/infra/llm-backend-onboarding/modules/policies/frag-set-backend-authorization.xml
+++ b/bicep/infra/llm-backend-onboarding/modules/policies/frag-set-backend-authorization.xml
@@ -26,10 +26,11 @@
                 <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
             </set-header>
             
-            <!-- Rewrite URL to inject /deployments/{model}/ path for Azure OpenAI API format -->
+            <!-- Rewrite URL to inject /openai/deployments/{deployment}/ prefix while preserving the original API path -->
             <set-variable name="rewriteTemplate" value="@{
                 string requestedModel = (string)context.Variables["requestedModel"];
-                return string.Format("/deployments/{0}/chat/completions", requestedModel);
+                string path = context.Request.Url.Path.TrimStart('/');
+                return string.Format("openai/deployments/{0}/{1}", requestedModel, path);
             }" />
             <rewrite-uri template="@((string)context.Variables["rewriteTemplate"])" copy-unmatched-params="true" />
         </when>
@@ -40,6 +41,13 @@
             <set-header name="Authorization" exists-action="override">
                 <value>@("Bearer " + (string)context.Variables["msi-access-token"])</value>
             </set-header>
+
+             <!-- Rewrite URL to /models/{original-api-path} format for AI Foundry -->
+            <set-variable name="rewriteTemplate" value="@{
+                string path = context.Request.Url.Path.TrimStart('/');
+                return string.Format("models/{0}", path);
+            }" />
+            <rewrite-uri template="@((string)context.Variables["rewriteTemplate"])" copy-unmatched-params="true" />
         </when>
         <when condition="@(((string)context.Variables["targetPoolType"]) == "external")">
             <!-- External LLM Provider: Authentication handled by backend credentials configuration -->


### PR DESCRIPTION
This pull request updates the API gateway policy logic for URL rewriting to better support Azure OpenAI and AI Foundry backends. The main changes clarify and generalize how incoming API paths are rewritten before being forwarded to the appropriate backend service.

**URL Rewrite Improvements:**

* For Azure OpenAI, the URL rewrite logic now injects the `/openai/deployments/{deployment}/` prefix and preserves the original API path, improving compatibility with various endpoints.
* For AI Foundry, a new URL rewrite step is added to map incoming requests to the `/models/{original-api-path}` format, standardizing how requests are routed to this backend.