### PR TITLE
fix(llm-backend-pools): Strip dot characters from model names in backend pool names

### DIFF
--- a/bicep/infra/llm-backend-onboarding/modules/llm-backend-pools.bicep
+++ b/bicep/infra/llm-backend-onboarding/modules/llm-backend-pools.bicep
@@ -52,11 +52,12 @@ var modelToBackendsMap = reduce(normalizedBackendDetails, {}, (acc, backend) => 
 }))))
 
 // Create pool configurations only for models supported by multiple backends
+// Note: Pool names must only contain letters, numbers, and hyphens (dots are stripped from model names)
 var poolConfigs = map(
   filter(items(modelToBackendsMap), (item) => length(item.value) > 1),
   (item) => {
     modelName: item.key
-    poolName: '${item.key}-backend-pool'
+    poolName: '${replace(item.key, '.', '')}-backend-pool'
     backends: item.value
   }
 )


### PR DESCRIPTION
## Problem
APIM backend pool names only support letters, numbers, and hyphens. Model deployment names like \gpt-4.1\ or \o1-pro.5\ contain dots which cause Bicep deployment failures when creating backend pools.

## Solution
Use \eplace()\ to strip dot characters from model names when generating backend pool names.

**Before:** \gpt-4.1\ → \gpt-4.1-backend-pool\ ❌ (invalid)
**After:** \gpt-4.1\ → \gpt-41-backend-pool\ ✅ (valid)

## Changes
- Added \eplace(item.key, '.', '')\ in pool name generation
- Added comment documenting the naming constraint