### PR TITLE
minor routing adjustments

### DIFF
--- a/bicep/infra/llm-backend-onboarding/README.md
+++ b/bicep/infra/llm-backend-onboarding/README.md
@@ -82,7 +82,7 @@ param llmBackendConfig = [
 ### 3. Deploy
 
 ```bash
-az deployment sub create --name llm-backend-onboarding --location swedencentral --template-file main.bicep --parameters llm-backends-dev-local.bicepparam
+az deployment sub create --name llm-backend-onboarding --location swedencentral --template-file main.bicep --parameters llm-backends-generated-local.bicepparam
 ```
 
 ## Configuration Reference

--- a/bicep/infra/llm-backend-onboarding/modules/policies/universal-llm-api-policy.xml
+++ b/bicep/infra/llm-backend-onboarding/modules/policies/universal-llm-api-policy.xml
@@ -54,7 +54,7 @@
             - Condition: Retries on 429 (throttling) or 503 (except when backend pool is unavailable)
             - Strategy: First fast retry with zero interval, buffer request body for replay
         -->
-        <retry count="2" interval="0" first-fast-retry="true" condition="@(context.Response.StatusCode == 429 || (context.Response.StatusCode == 503 &amp;&amp; !context.Response.StatusReason.Contains(&quot;Backend pool&quot;) &amp;&amp; !context.Response.StatusReason.Contains(&quot;is temporarily unavailable&quot;)))">
+        <retry count="2" interval="0" first-fast-retry="true" condition="@(context.Response.StatusCode == 429 || (context.Response.StatusCode >= 500 &amp;&amp; !context.Response.StatusReason.Contains(&quot;Backend pool&quot;) &amp;&amp; !context.Response.StatusReason.Contains(&quot;is temporarily unavailable&quot;)))">
             <forward-request buffer-request-body="true" />
         </retry>
     </backend>

--- a/bicep/infra/modules/apim/llm-backend-pools.bicep
+++ b/bicep/infra/modules/apim/llm-backend-pools.bicep
@@ -68,7 +68,7 @@ var poolConfigs = map(
   filter(items(modelToBackendsMap), (item) => length(item.value) > 1),
   (item) => {
     modelName: item.key
-    poolName: '${item.key}-backend-pool'
+    poolName: '${replace(item.key, '.', '')}-backend-pool'
     backends: item.value
   }
 )

--- a/bicep/infra/modules/apim/policies/azure-open-ai-api-policy.xml
+++ b/bicep/infra/modules/apim/policies/azure-open-ai-api-policy.xml
@@ -87,7 +87,7 @@
             - Condition: Retries on 429 (throttling) or 503 (except when backend pool is unavailable)
             - Strategy: First fast retry with zero interval, buffer request body for replay
         -->
-        <retry count="2" interval="0" first-fast-retry="true" condition="@(context.Response.StatusCode == 429 || (context.Response.StatusCode == 503 && !context.Response.StatusReason.Contains("Backend pool") && !context.Response.StatusReason.Contains("is temporarily unavailable")))">
+        <retry count="2" interval="0" first-fast-retry="true" condition="@(context.Response.StatusCode == 429 || (context.Response.StatusCode >= 500 && !context.Response.StatusReason.Contains("Backend pool") && !context.Response.StatusReason.Contains("is temporarily unavailable")))">
             <forward-request buffer-request-body="true" />
         </retry>
     </backend>

--- a/bicep/infra/modules/apim/policies/universal-llm-api-policy-v2.xml
+++ b/bicep/infra/modules/apim/policies/universal-llm-api-policy-v2.xml
@@ -61,7 +61,7 @@
             - Condition: Retries on 429 (throttling) or 503 (except when backend pool is unavailable)
             - Strategy: First fast retry with zero interval, buffer request body for replay
         -->
-        <retry count="2" interval="0" first-fast-retry="true" condition="@(context.Response.StatusCode == 429 || (context.Response.StatusCode == 503 && !context.Response.StatusReason.Contains("Backend pool") && !context.Response.StatusReason.Contains("is temporarily unavailable")))">
+        <retry count="2" interval="0" first-fast-retry="true" condition="@(context.Response.StatusCode == 429 || (context.Response.StatusCode >= 500 && !context.Response.StatusReason.Contains("Backend pool") && !context.Response.StatusReason.Contains("is temporarily unavailable")))">
             <forward-request buffer-request-body="true" />
         </retry>
     </backend>

--- a/guides/llm-routing-architecture.md
+++ b/guides/llm-routing-architecture.md
@@ -246,7 +246,7 @@ Both APIs implement automatic retry on transient failures:
 ```xml
 <retry count="2" interval="0" first-fast-retry="true" 
        condition="@(context.Response.StatusCode == 429 || 
-                    context.Response.StatusCode == 503)">
+                    context.Response.StatusCode >= 500)">
     <forward-request buffer-request-body="true" />
 </retry>
 ```


### PR DESCRIPTION
This pull request introduces improvements to the retry logic for LLM backend APIs and updates naming conventions for backend pools. The most significant changes are the expansion of retry conditions to include all 5xx errors (not just 503), and a fix to pool name generation to remove periods from model names.

**Retry Logic Improvements**
* Updated retry conditions in `azure-open-ai-api-policy.xml`, `universal-llm-api-policy.xml`, and `universal-llm-api-policy-v2.xml` to trigger retries for any HTTP 5xx error (server errors), instead of only 503, while still excluding specific backend pool unavailability reasons. [[1]](diffhunk://#diff-15c0140cf5d478c1f281999991641475bb2a646733bfe79c97e5d087a865f95dL90-R90) [[2]](diffhunk://#diff-32cac4cd6cde34c785e6024cf1fe0b9116c20de1d08b4009e8a068a42bdf538fL57-R57) [[3]](diffhunk://#diff-39bef4053a50ba0aea22ae957cb9c2be0f742aedab6a127def6ef81df0a3730eL64-R64)
* Updated documentation in `llm-routing-architecture.md` to reflect the new retry condition for 5xx errors.

**Naming Convention Fixes**
* Changed backend pool name generation in `llm-backend-pools.bicep` to remove periods from model names, ensuring valid resource naming.

**Deployment Script Update**
* Updated the deployment command in `llm-backend-onboarding/README.md` to use the correct parameter file name.