### PR TITLE
Citadel v1 - LLM Onboarding Adjustments

### DIFF
--- a/bicep/infra/citadel-access-contracts/README.md
+++ b/bicep/infra/citadel-access-contracts/README.md
@@ -9,7 +9,7 @@ This package eliminates manual APIM configuration by providing:
 - 🔌 **API Integration**: Automatic API attachment to product with custom or default policies
 - 🔑 **Subscription Management**: Auto-generated subscription with secure API keys
 - 🔐 **Flexible Secret Storage**: Optional Azure Key Vault integration or direct credential output
-- 🤖 **Azure AI Foundry Integration**: Optional APIM connection creation for Foundry agents
+- 🤖 **Azure Microsoft Foundry Integration**: Optional APIM connection creation for Foundry agents
 - 📝 **Declarative Configuration**: Simple `.bicepparam` & `.xml` files for version control per use case
 
 ## What Gets Created
@@ -19,7 +19,7 @@ This package eliminates manual APIM configuration by providing:
 | **APIM Product** | `{code}-{BU}-{UseCase}-{ENV}` | Product per service (e.g., `LLM-Healthcare-PatientAssistant-DEV`) with attached APIs and policies |
 | **APIM Subscription** | `{product}-SUB-01` | Subscription with API key |
 | **Key Vault Secrets** | `{secretName}` | Endpoint URL and API key (optional) |
-| **Foundry Connection** | `{prefix}-{code}` | APIM connection for AI Foundry agents (optional) |
+| **Foundry Connection** | `{prefix}-{code}` | APIM connection for Microsoft Foundry agents (optional) |
 
 ## Key Features
 
@@ -100,7 +100,7 @@ Below is a suggested flow for client applications (i.e. agents) interacting with
 sequenceDiagram
     participant App as AI Agent/App
     participant KV as Azure Key Vault
-    participant Foundry as AI Foundry
+    participant Foundry as Microsoft Foundry
     participant APIM as AI Gateway
     participant AI as AI Services
 
@@ -137,7 +137,7 @@ citadel-access-contracts/
 │   ├── apimProduct.bicep               # APIM product module
 │   ├── apimSubscription.bicep          # Subscription module
 │   ├── kvSecrets.bicep                 # Key Vault secret storage
-│   └── foundryConnection.bicep         # Azure AI Foundry connection module
+│   └── foundryConnection.bicep         # Azure Microsoft Foundry connection module
 ├── policies/
 │   └── default-ai-product-policy.xml   # Default product policy
 ├── contracts/                          # Use-case contracts folder for source control 
@@ -181,7 +181,7 @@ citadel-access-contracts/
 | `services` | array | ✅ | Services to onboard | See [Services Schema](#services-schema) below |
 | `productTerms` | string | ❌ | Product terms of service | "By using this product..." |
 | `useTargetFoundry` | bool | ❌ | Create Foundry connections (default: `false`) | `true` or `false` |
-| `foundry` | object | ❌* | AI Foundry coordinates (*required if useTargetFoundry=true) | `{ subscriptionId, resourceGroupName, accountName, projectName }` |
+| `foundry` | object | ❌* | Microsoft Foundry coordinates (*required if useTargetFoundry=true) | `{ subscriptionId, resourceGroupName, accountName, projectName }` |
 | `foundryConfig` | object | ❌ | Foundry connection configuration | See [Foundry Config](#foundry-configuration) below |
 
 
@@ -242,7 +242,7 @@ But each service will have its own product + subscription + secrets (i.e llm wil
 | APIM Product | APIM | `<serviceCode>-<BU>-<UseCase>-<ENV>` | One per service code you include |
 | APIM Subscription | APIM | `<product>-SUB-01` | Primary key is captured into Key Vault |
 | Key Vault Secrets | KV | `endpointSecretName`, `apiKeySecretName` | One endpoint + one key per service |
-| Foundry Connection | AI Foundry | `<prefix>-<serviceCode>` | One connection per service (if enabled) |
+| Foundry Connection | Microsoft Foundry | `<prefix>-<serviceCode>` | One connection per service (if enabled) |
 
 Naming examples
 - Product: `LLM-Retail-FinancialAssistant-DEV`
@@ -259,7 +259,7 @@ Naming examples
 |----------|-------------|---------------|
 | **Citadel Compliant APIM Instance** | with published APIs matching your `apiNameMapping` | `az apim api list -g <rg> -n <apim-name>` |
 | **Azure Key Vault** | Accessible with secret set permissions (if using KV) | `az keyvault show -n <kv-name>` |
-| **Azure AI Foundry** | Account and project must exist (if using Foundry) | `az cognitiveservices account show -n <account-name> -g <rg>` |
+| **Azure Microsoft Foundry** | Account and project must exist (if using Foundry) | `az cognitiveservices account show -n <account-name> -g <rg>` |
 
 ### Permissions Required
 
@@ -269,7 +269,7 @@ The deployment identity needs:
 |-------|------|---------|
 | APIM Resource Group | `API Management Service Contributor` | Create products and subscriptions |
 | Target Key Vault (if used) | `Key Vault Secrets Officer` | Write secrets |
-| AI Foundry Resource Group (if used) | `Contributor` | Create connections |
+| Microsoft Foundry Resource Group (if used) | `Contributor` | Create connections |
 | Subscription | `Reader` | Reference existing resources |
 
 ---
@@ -505,7 +505,7 @@ param foundryConfig = {
 ```
 
 **Benefits**:
-- ✅ Seamless integration with AI Foundry agents
+- ✅ Seamless integration with Microsoft Foundry agents
 - ✅ Credentials stored securely in Foundry connection
 - ✅ Supports the "Bring Your Own AI Gateway" pattern
 - ✅ Automatic model discovery from APIM
@@ -736,6 +736,5 @@ Write-Host "##vso[task.setvariable variable=OAI_KEY;issecret=true]$($oaiCreds.ap
 
 For issues or questions:
 - **GitHub Issues**: [Report bugs or request features](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/issues)
-- **Documentation**: Review the guides in `/guides`
 
 ---

--- a/bicep/infra/citadel-access-contracts/README.md
+++ b/bicep/infra/citadel-access-contracts/README.md
@@ -1,4 +1,4 @@
-# 🚀 Use Case Onboarding for AI Citadel Governance Hub
+# 📜 Citadel Access Contracts - Use-case onboarding
 
 ## Overview
 

--- a/bicep/infra/llm-backend-onboarding/modules/policies/frag-set-target-backend-pool.xml
+++ b/bicep/infra/llm-backend-onboarding/modules/policies/frag-set-target-backend-pool.xml
@@ -17,6 +17,13 @@
     <!-- Determine target backend pool based on requested model and RBAC permissions -->
     <set-variable name="targetBackendPool" value="@{
         string requestedModel = (string)context.Variables["requestedModel"];
+        
+        // Skip backend pool routing for non-LLM requests (e.g., GET operations like listing models)
+        if (requestedModel == "non-llm-request")
+        {
+            return "non-llm-request";
+        }
+        
         string defaultBackendPool = (string)context.Variables["defaultBackendPool"];
         string allowedBackendPools = (string)context.Variables["allowedBackendPools"];
         JArray backendPools = (JArray)context.Variables["backendPools"];
@@ -77,6 +84,9 @@
 
     <!-- Validate target backend pool and return appropriate error response if needed -->
     <choose>
+        <when condition="@((string)context.Variables["targetBackendPool"] == "non-llm-request")">
+            <!-- Non-LLM request - skip backend pool validation and routing -->
+        </when>
         <when condition="@(((string)context.Variables["targetBackendPool"]).StartsWith("ERROR_"))">
             <choose>
                 <when condition="@(((string)context.Variables["targetBackendPool"]) == "ERROR_NO_MODEL")">
@@ -158,6 +168,13 @@
     <!-- Set poolType variable based on the target backend pool -->
     <set-variable name="targetPoolType" value="@{
         string targetBackendPool = (string)context.Variables["targetBackendPool"];
+        
+        // Skip for non-LLM requests
+        if (targetBackendPool == "non-llm-request")
+        {
+            return "non-llm-request";
+        }
+        
         JArray backendPools = (JArray)context.Variables["backendPools"];
 
         foreach (JObject pool in backendPools)


### PR DESCRIPTION
This pull request primarily updates documentation to clarify that the integration is with Microsoft Foundry rather than AI Foundry, and introduces logic in the backend policy to correctly handle non-LLM requests by skipping backend pool routing and validation. These changes improve clarity for users and robustness in request handling.

**Documentation updates (Microsoft Foundry clarification):**
* Updated all references from "AI Foundry" to "Microsoft Foundry" throughout `README.md` to ensure correct branding and prevent confusion. This includes feature lists, resource descriptions, diagrams, parameter tables, and permissions. [[1]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L1-R1) [[2]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L12-R12) [[3]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L22-R22) [[4]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L103-R103) [[5]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L140-R140) [[6]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L184-R184) [[7]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L245-R245) [[8]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L262-R262) [[9]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L272-R272) [[10]](diffhunk://#diff-e8cf480cbe31b5e6453843ba55b3e8b9bccb4940a0854b06249686c4fc89d1b8L508-R508)

**Backend policy improvements (non-LLM request handling):**
* Added logic in `frag-set-target-backend-pool.xml` to detect and skip backend pool routing for non-LLM requests, such as GET operations for listing models. This prevents unnecessary validation and routing for requests that do not require LLM backend selection. [[1]](diffhunk://#diff-7752c32e35937d822cbd86e9aa3779f410c18e27ef3dc206fb946ab075031e83R20-R26) [[2]](diffhunk://#diff-7752c32e35937d822cbd86e9aa3779f410c18e27ef3dc206fb946ab075031e83R87-R89) [[3]](diffhunk://#diff-7752c32e35937d822cbd86e9aa3779f410c18e27ef3dc206fb946ab075031e83R171-R177)