### PR TITLE
Security: Enforce TLS 1.2 on Storage Accounts

### DIFF
--- a/bicep/infra/modules/functionapp/storageaccount.bicep
+++ b/bicep/infra/modules/functionapp/storageaccount.bicep
@@ -67,6 +67,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2022-05-01' = {
   kind: 'StorageV2'
   properties: {
     supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
     publicNetworkAccess: 'Disabled'
     allowBlobPublicAccess: false
     accessTier: 'Hot'


### PR DESCRIPTION
## Description

The current storage account deployment uses API version **2022-05-01**, which defaults the `minimumTlsVersion` property to **TLS 1.0** when it is not explicitly specified.

To align with security best practices and avoid relying on a legacy default, this change explicitly sets `minimumTlsVersion` to **TLS1_2** during storage account creation.

This ensures all requests to the storage account enforce TLS 1.2 or higher, improving the overall security posture and compliance.

## Reference

- [Microsoft.Storage storageAccounts – API version 2022-05-01](https://learn.microsoft.com/en-us/azure/templates/microsoft.storage/2022-05-01/storageaccounts?pivots=deployment-language-bicep#bicep-resource-definition)
