### PR TITLE
added diagnostic and monitoring settings to parameter file

### DIFF
--- a/bicep/infra/citadel-access-contracts/policies/default-ai-product-policy.xml
+++ b/bicep/infra/citadel-access-contracts/policies/default-ai-product-policy.xml
@@ -18,7 +18,7 @@
         <include-fragment fragment-id="validate-model-access" />
 
         <!-- Capacity management - Subscription Level: allow only assigned tpm for each HR use case subscription -->
-        <llm-token-limit counter-key="@(context.Subscription.Id)" tokens-per-minute="400" estimate-prompt-tokens="false" tokens-consumed-header-name="consumed-tokens" remaining-tokens-header-name="remaining-tokens" token-quota="100000" token-quota-period="Monthly" retry-after-header-name="retry-after" />
+        <llm-token-limit counter-key="@(context.Subscription.Id)" tokens-per-minute="400" estimate-prompt-tokens="false" tokens-consumed-header-name="x-ratelimit-consumed-tokens" remaining-tokens-header-name="x-ratelimit-remaining-tokens" token-quota="100000" token-quota-period="Monthly" retry-after-header-name="retry-after" />
         
         <!-- Failure to pass content safety will result in 403 error -->
         <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">

--- a/bicep/infra/main.bicep
+++ b/bicep/infra/main.bicep
@@ -286,6 +286,29 @@ param enableAPICenter bool = true
 @description('Enable Azure Managed Redis (AMR). When true (default), the Redis resource and APIM cache integration are provisioned.')
 param enableManagedRedis bool = true
 
+@description('Azure Monitor diagnostic log settings for inference APIs. Controls frontend/backend request/response headers, body bytes, and LLM-specific log settings.')
+param azureMonitorLogSettings object = {
+  frontend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  backend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  largeLanguageModel: {
+    logs: 'enabled'
+    requests:  { messages: 'all', maxSizeInBytes: 262144 }
+    responses: { messages: 'all', maxSizeInBytes: 262144 }
+  }
+}
+
+@description('Application Insights diagnostic log settings for inference APIs. Controls which headers are captured and body byte limits.')
+param appInsightsLogSettings object = {
+  headers: [ 'Content-type', 'User-agent', 'x-ms-region', 'x-ratelimit-remaining-tokens', 'x-ratelimit-remaining-requests' ]
+  body: { bytes: 0 }
+}
+
 //
 // COMPUTE SKU & SIZE - SKUs and capacity settings for services
 //
@@ -997,6 +1020,8 @@ module apim './modules/apim/apim.bicep' = {
     enableAPICenter: enableAPICenter
     apiCenterServiceName: enableAPICenter ? apiCenter.outputs.name : ''
     apiCenterWorkspaceName: enableAPICenter ? apiCenter.outputs.defaultWorkspaceName : 'default'
+    azureMonitorLogSettings: azureMonitorLogSettings
+    appInsightsLogSettings: appInsightsLogSettings
 
   }
 }

--- a/bicep/infra/main.bicepparam
+++ b/bicep/infra/main.bicepparam
@@ -133,6 +133,36 @@ param enableAPICenter = bool(readEnvironmentVariable('ENABLE_API_CENTER', 'false
 param enableManagedRedis = bool(readEnvironmentVariable('ENABLE_MANAGED_REDIS', 'true'))
 
 // ============================================================================
+// INFERENCE API DIAGNOSTIC LOG SETTINGS
+// ============================================================================
+
+// Azure Monitor diagnostic log settings for inference APIs
+// Controls frontend/backend request/response headers, body bytes, and LLM-specific log settings.
+// Max size in bytes for request/response bodies is 262144 bytes (256 KB).
+param azureMonitorLogSettings = {
+  frontend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  backend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: ['Content-type', 'User-agent', 'x-ms-region', 'x-ratelimit-remaining-tokens', 'x-ratelimit-remaining-requests'], body: { bytes: 0 } }
+  }
+  largeLanguageModel: {
+    logs: 'enabled'
+    requests:  { messages: 'all', maxSizeInBytes: 262144 }
+    responses: { messages: 'all', maxSizeInBytes: 262144 }
+  }
+}
+
+// Application Insights diagnostic log settings for inference APIs
+// Controls which headers are captured and body byte limits (max 8192 bytes).
+param appInsightsLogSettings = {
+  headers: [ 'Content-type', 'User-agent', 'x-ms-region', 'x-ratelimit-remaining-tokens', 'x-ratelimit-remaining-requests' ]
+  body: { bytes: 8192 }
+}
+
+// ============================================================================
 // COMPUTE SKU & SIZE - SKUs and capacity settings for services
 // ============================================================================
 param apimSku = readEnvironmentVariable('APIM_SKU', 'StandardV2')

--- a/bicep/infra/modules/apim/apim.bicep
+++ b/bicep/infra/modules/apim/apim.bicep
@@ -97,6 +97,29 @@ param redisCacheResourceId string = ''
 @description('APIM cache entity name for the Redis-backed cache')
 param apimRedisCacheName string = 'redis-cache'
 
+@description('Azure Monitor diagnostic log settings for inference APIs (frontend/backend request/response headers & body bytes, and LLM log settings).')
+param azureMonitorLogSettings object = {
+  frontend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  backend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  largeLanguageModel: {
+    logs: 'enabled'
+    requests:  { messages: 'all', maxSizeInBytes: 262144 }
+    responses: { messages: 'all', maxSizeInBytes: 262144 }
+  }
+}
+
+@description('Application Insights diagnostic log settings for inference APIs (headers to capture and body bytes).')
+param appInsightsLogSettings object = {
+  headers: [ 'Content-type', 'User-agent', 'x-ms-region', 'x-ratelimit-remaining-tokens', 'x-ratelimit-remaining-requests' ]
+  body: { bytes: 0 }
+}
+
 @description('Enable an APIM backend that targets the AI Foundry embeddings endpoint')
 param enableEmbeddingsBackend bool = false
 
@@ -369,6 +392,8 @@ module apiUniversalLLM './inference-api.bicep' = {
     allowSubscriptionKey: entraAuth ? false:true
     apimLoggerId: apimAzMonitorLogger.id
     policyXml: loadTextContent('./policies/universal-llm-api-policy-v2.xml')
+    azureMonitorLogSettings: azureMonitorLogSettings
+    appInsightsLogSettings: appInsightsLogSettings
   }
   dependsOn: [
     policyFragments
@@ -390,6 +415,8 @@ module apimOpenaiApi './inference-api.bicep' = {
     allowSubscriptionKey: entraAuth ? false:true
     apimLoggerId: apimAzMonitorLogger.id
     policyXml: loadTextContent('./policies/azure-open-ai-api-policy.xml')
+    azureMonitorLogSettings: azureMonitorLogSettings
+    appInsightsLogSettings: appInsightsLogSettings
   }
   dependsOn: [
     policyFragments

--- a/bicep/infra/modules/apim/inference-api.bicep
+++ b/bicep/infra/modules/apim/inference-api.bicep
@@ -60,13 +60,36 @@ param inferenceAPIPath string = 'inference' // Path to the inference API in the 
 @description('Whether to configure the circuit breaker for the inference backend')
 param configureCircuitBreaker bool = false
 
+@description('Azure Monitor diagnostic log settings for the inference API (frontend/backend request/response headers & body bytes, and LLM log settings).')
+param azureMonitorLogSettings object = {
+  frontend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  backend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  largeLanguageModel: {
+    logs: 'enabled'
+    requests:  { messages: 'all', maxSizeInBytes: 262144 }
+    responses: { messages: 'all', maxSizeInBytes: 262144 }
+  }
+}
+
+@description('Application Insights diagnostic log settings for the inference API (headers to capture and body bytes).')
+param appInsightsLogSettings object = {
+  headers: [ 'Content-type', 'User-agent', 'x-ms-region', 'x-ratelimit-remaining-tokens', 'x-ratelimit-remaining-requests' ]
+  body: { bytes: 0 }
+}
+
 // ------------------
 //    VARIABLES
 // ------------------
 
 var logSettings = {
-  headers: [ 'Content-type', 'User-agent', 'x-ms-region', 'x-ratelimit-remaining-tokens' , 'x-ratelimit-remaining-requests' ]
-  body: { bytes: 0 }
+  headers: appInsightsLogSettings.headers
+  body: appInsightsLogSettings.body
 }
 
 // to allow future modifications to the policy XML if needed
@@ -142,41 +165,41 @@ resource apiDiagnostics 'Microsoft.ApiManagement/service/apis/diagnostics@2024-0
     }
     frontend: {
       request: {
-        headers: []
+        headers: azureMonitorLogSettings.frontend.request.headers
         body: {
-          bytes: 0
+          bytes: azureMonitorLogSettings.frontend.request.body.bytes
         }
       }
       response: {
-        headers: []
+        headers: azureMonitorLogSettings.frontend.response.headers
         body: {
-          bytes: 0
+          bytes: azureMonitorLogSettings.frontend.response.body.bytes
         }
       }
     }
     backend: {
       request: {
-        headers: []
+        headers: azureMonitorLogSettings.backend.request.headers
         body: {
-          bytes: 0
+          bytes: azureMonitorLogSettings.backend.request.body.bytes
         }
       }
       response: {
-        headers: []
+        headers: azureMonitorLogSettings.backend.response.headers
         body: {
-          bytes: 0
+          bytes: azureMonitorLogSettings.backend.response.body.bytes
         }
       }
     }
     largeLanguageModel: {
-      logs: 'enabled'
+      logs: azureMonitorLogSettings.largeLanguageModel.logs
       requests: {
-        messages: 'all'
-        maxSizeInBytes: 262144
+        messages: azureMonitorLogSettings.largeLanguageModel.requests.messages
+        maxSizeInBytes: azureMonitorLogSettings.largeLanguageModel.requests.maxSizeInBytes
       }
       responses: {
-        messages: 'all'
-        maxSizeInBytes: 262144
+        messages: azureMonitorLogSettings.largeLanguageModel.responses.messages
+        maxSizeInBytes: azureMonitorLogSettings.largeLanguageModel.responses.maxSizeInBytes
       }
     }
   }

--- a/bicep/infra/modules/apim/policies/azure-open-ai-api-policy.xml
+++ b/bicep/infra/modules/apim/policies/azure-open-ai-api-policy.xml
@@ -27,18 +27,22 @@
         <include-fragment fragment-id="set-llm-requested-model" />
         
         <!-- Step 3: Inject model parameter into request body if not present -->
-        <set-body>@{
-            var body = context.Request.Body.As<JObject>(preserveContent: true);
-            string requestedModel = (string)context.Variables["requestedModel"];
-            
-            // Only inject model if it doesn't already exist in the body
-            if (body["model"] == null)
-            {
-                body["model"] = requestedModel;
-            }
-            
-            return body.ToString();
-        }</set-body>
+        <choose>
+            <when condition="@((string)context.Variables["requestedModel"] != "non-llm-request")">
+                <set-body>@{
+                    var body = context.Request.Body.As<JObject>(preserveContent: true);
+                    string requestedModel = (string)context.Variables["requestedModel"];
+                    
+                    // Only inject model if it doesn't already exist in the body
+                    if (body["model"] == null)
+                    {
+                        body["model"] = requestedModel;
+                    }
+                    
+                    return body.ToString();
+                }</set-body>
+            </when>
+        </choose>
 
         <!-- Step 3.1: capture original API path -->
          <set-variable name="openAIRewriteTemplate" value="@{

--- a/guides/full-deployment-guide.md
+++ b/guides/full-deployment-guide.md
@@ -15,7 +15,8 @@ For quick non-production deployments, see the [Quick Deployment Guide](./quick-d
    - [Network Architecture](#3-network-architecture)
    - [AI Model Deployment](#4-ai-model-deployment-optional)
    - [Log Analytics Strategy](#5-log-analytics-strategy)
-   - [Security & Compliance](#6-security--compliance)
+   - [Inference API Diagnostic Logging](#6-inference-api-diagnostic-logging)
+   - [Security & Compliance](#7-security--compliance)
 3. [Source Control Strategy](#-source-control-strategy)
 4. [Deployment Execution](#-deployment-execution)
 5. [Environment-Specific Configurations](#-environment-specific-configurations)
@@ -70,6 +71,10 @@ Use the below checklist to plan your deployment configuration:
   - [ ] Development (cost-optimized SKUs)
   - [ ] Staging (production SKUs with reduced capacity)
   - [ ] Production (production SKUs with full capacity)
+- [ ] Inference API Diagnostic Logging
+  - [ ] Azure Monitor LLM log verbosity (enabled/disabled, message capture, max payload size)
+  - [ ] Application Insights log headers and body capture size
+  - [ ] Use defaults (recommended) or customize per environment
 - [ ] Source Control Strategy
   - [ ] Single repository with branches per environment
       - [ ] Branch for original unchanged Citadel Governance Hub repo (synchronized with upstream)
@@ -640,7 +645,148 @@ param existingLogAnalyticsSubscriptionId = '00000000-0000-0000-0000-000000000000
 
 ---
 
-### 6. Security & Compliance
+### 6. Inference API Diagnostic Logging
+
+AI Citadel configures **per-API diagnostic logging** on every inference API (Universal LLM API and Azure OpenAI API). Two diagnostic channels are provisioned:
+
+| Channel | Purpose | Default Destination |
+|---------|---------|--------------------|
+| **Azure Monitor** (`azuremonitor`) | LLM-aware diagnostics sent to Log Analytics | Azure Monitor / Log Analytics |
+| **Application Insights** (`applicationinsights`) | Request/response tracing with custom headers | Application Insights |
+
+Both channels are fully configurable through the deployment parameter files.
+
+#### Azure Monitor Log Settings (`azureMonitorLogSettings`)
+
+Controls frontend/backend request and response header capture, body byte limits, and **LLM-specific** log settings (prompt/completion logging).
+
+**Default values:**
+
+```bicep
+param azureMonitorLogSettings = {
+  frontend: {
+    request:  { headers: [], body: { bytes: 0 } }   // No frontend headers/body captured by default
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  backend: {
+    request:  { headers: [], body: { bytes: 0 } }   // No backend headers/body captured by default
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  largeLanguageModel: {
+    logs: 'enabled'                                  // LLM logging enabled
+    requests:  { messages: 'all', maxSizeInBytes: 262144 }  // Capture all prompt messages (up to 256 KB)
+    responses: { messages: 'all', maxSizeInBytes: 262144 }  // Capture all completion messages (up to 256 KB)
+  }
+}
+```
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `frontend.request.headers` | `[]` | HTTP headers to capture from the client request |
+| `frontend.request.body.bytes` | `0` | Max bytes of client request body to log (`0` = none) |
+| `frontend.response.headers` | `[]` | HTTP headers to capture from the response to client |
+| `frontend.response.body.bytes` | `0` | Max bytes of response body to log (`0` = none) |
+| `backend.request.headers` | `[]` | HTTP headers to capture from the backend request |
+| `backend.request.body.bytes` | `0` | Max bytes of backend request body to log (`0` = none) |
+| `backend.response.headers` | `[]` | HTTP headers to capture from backend response |
+| `backend.response.body.bytes` | `0` | Max bytes of backend response body to log (`0` = none) |
+| `largeLanguageModel.logs` | `'enabled'` | Enable or disable LLM-specific logging (`'enabled'` / `'disabled'`) |
+| `largeLanguageModel.requests.messages` | `'all'` | Which prompt messages to capture (`'all'` / `'none'`) |
+| `largeLanguageModel.requests.maxSizeInBytes` | `262144` | Maximum prompt payload size in bytes (256 KB) |
+| `largeLanguageModel.responses.messages` | `'all'` | Which completion messages to capture (`'all'` / `'none'`) |
+| `largeLanguageModel.responses.maxSizeInBytes` | `262144` | Maximum completion payload size in bytes (256 KB) |
+
+**Example — Production with header capture and reduced LLM payload:**
+```bicep
+param azureMonitorLogSettings = {
+  frontend: {
+    request:  { headers: [ 'Content-type', 'User-agent' ], body: { bytes: 0 } }
+    response: { headers: [ 'x-ms-region' ], body: { bytes: 0 } }
+  }
+  backend: {
+    request:  { headers: [ 'Content-type' ], body: { bytes: 8192 } }
+    response: { headers: [ 'x-ratelimit-remaining-tokens', 'x-ratelimit-remaining-requests' ], body: { bytes: 8192 } }
+  }
+  largeLanguageModel: {
+    logs: 'enabled'
+    requests:  { messages: 'all', maxSizeInBytes: 131072 }  // 128 KB limit
+    responses: { messages: 'all', maxSizeInBytes: 131072 }
+  }
+}
+```
+
+**Example — Disable LLM prompt/completion logging (privacy-sensitive environments):**
+```bicep
+param azureMonitorLogSettings = {
+  frontend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  backend: {
+    request:  { headers: [], body: { bytes: 0 } }
+    response: { headers: [], body: { bytes: 0 } }
+  }
+  largeLanguageModel: {
+    logs: 'disabled'
+    requests:  { messages: 'none', maxSizeInBytes: 0 }
+    responses: { messages: 'none', maxSizeInBytes: 0 }
+  }
+}
+```
+
+---
+
+#### Application Insights Log Settings (`appInsightsLogSettings`)
+
+Controls which HTTP headers are captured and how many bytes of request/response body are logged to Application Insights for all inference APIs.
+
+**Default values:**
+
+```bicep
+param appInsightsLogSettings = {
+  headers: [ 'Content-type', 'User-agent', 'x-ms-region', 'x-ratelimit-remaining-tokens', 'x-ratelimit-remaining-requests' ]
+  body: { bytes: 0 }  // No body captured by default
+}
+```
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `headers` | `[ 'Content-type', 'User-agent', 'x-ms-region', 'x-ratelimit-remaining-tokens', 'x-ratelimit-remaining-requests' ]` | HTTP headers captured in both frontend and backend request/response traces |
+| `body.bytes` | `0` | Max bytes of request/response body to log (`0` = none) |
+
+**Example — Capture up to 8 KB of body content:**
+```bicep
+param appInsightsLogSettings = {
+  headers: [ 'Content-type', 'User-agent', 'x-ms-region', 'x-ratelimit-remaining-tokens', 'x-ratelimit-remaining-requests' ]
+  body: { bytes: 8192 }
+}
+```
+
+**Example — Minimal header capture for cost-sensitive environments:**
+```bicep
+param appInsightsLogSettings = {
+  headers: [ 'Content-type' ]
+  body: { bytes: 0 }
+}
+```
+
+---
+
+#### Recommended Settings by Environment
+
+| Setting | Development | Staging | Production |
+|---------|-------------|---------|------------|
+| **Azure Monitor LLM logs** | `'enabled'` | `'enabled'` | `'enabled'` (or `'disabled'` for PII-sensitive workloads) |
+| **LLM messages capture** | `'all'` | `'all'` | `'all'` or `'none'` |
+| **LLM max payload (bytes)** | `262144` (256 KB) | `262144` (256 KB) | `131072`–`262144` (128–256 KB) |
+| **App Insights body bytes** | `8192` (8 KB) | `0` | `0` |
+| **App Insights headers** | All 5 defaults | All 5 defaults | All 5 defaults |
+
+> **Note:** Increasing body byte capture or LLM payload sizes will increase Log Analytics and Application Insights ingestion costs. For production environments, balance observability needs against cost and data-sensitivity requirements.
+
+---
+
+### 7. Security & Compliance
 
 #### Entra ID Authentication
 


### PR DESCRIPTION
This pull request introduces improved configurability and granularity for diagnostic logging and rate limiting in the inference API infrastructure. It adds new parameters for Azure Monitor and Application Insights log settings, propagates these settings through the Bicep modules, and updates API Management (APIM) diagnostic resources to use these configurable values. Additionally, it refines rate limit response headers and improves request body handling in OpenAI API policies.

**Diagnostic logging configuration improvements:**

* Added `azureMonitorLogSettings` and `appInsightsLogSettings` parameters to `main.bicep`, `apim.bicep`, and `inference-api.bicep`, allowing fine-grained control over which headers and body bytes are logged for frontend, backend, and LLM-specific operations. These settings are now passed through the module hierarchy and used in APIM diagnostics resources. [[1]](diffhunk://#diff-f66e545bccaaa3ea3b75756138e4fd95b9d90ea160ed66b18a241269178faf14R289-R311) [[2]](diffhunk://#diff-26d0b4d989e5d37a41f87c721989b0e60ad71e9fa8aaeeddf6cab7dd8d3e08a2R135-R164) [[3]](diffhunk://#diff-e4150ae8b5158746366024e8568d1c4e7418db207d470282fc46e42d787d16a5R100-R122) [[4]](diffhunk://#diff-f66e545bccaaa3ea3b75756138e4fd95b9d90ea160ed66b18a241269178faf14R1023-R1024) [[5]](diffhunk://#diff-e4150ae8b5158746366024e8568d1c4e7418db207d470282fc46e42d787d16a5R395-R396) [[6]](diffhunk://#diff-e4150ae8b5158746366024e8568d1c4e7418db207d470282fc46e42d787d16a5R418-R419) [[7]](diffhunk://#diff-f86b2785977588653b024ec2b7fd279a9b5668cd8ea7dc2fc45d9727e5139c5eR63-R92) [[8]](diffhunk://#diff-f86b2785977588653b024ec2b7fd279a9b5668cd8ea7dc2fc45d9727e5139c5eL145-R202)

**Rate limiting and response header standardization:**

* Changed the `llm-token-limit` policy in `default-ai-product-policy.xml` to use `x-ratelimit-consumed-tokens` and `x-ratelimit-remaining-tokens` as response headers for better standardization and observability.

**Policy logic enhancements:**

* Updated the OpenAI API policy to conditionally set the request body only when the requested model is not `"non-llm-request"`, preventing unnecessary body modifications for non-LLM requests. [[1]](diffhunk://#diff-15c0140cf5d478c1f281999991641475bb2a646733bfe79c97e5d087a865f95dR30-R31) [[2]](diffhunk://#diff-15c0140cf5d478c1f281999991641475bb2a646733bfe79c97e5d087a865f95dR44-R45)