### PR TITLE
docs(deployment): Add Microsoft.AlertsManagement to required resource providers

### DIFF
--- a/guides/full-deployment-guide.md
+++ b/guides/full-deployment-guide.md
@@ -103,6 +103,7 @@ Then register all required resource providers:
 
 ```bash
 # Register all required providers
+az provider register --namespace Microsoft.AlertsManagement
 az provider register --namespace Microsoft.ApiCenter
 az provider register --namespace Microsoft.ApiManagement
 az provider register --namespace Microsoft.App


### PR DESCRIPTION
After registering documented resource providers for a new subscription, main.bicep deployment was failing due to missing Microsoft.AlertsManagement provider.  Added to full-deployment-guide.md.