### PR TITLE
Reduce Azure Managed Redis SKU and instance count for Dev environment

### DIFF
--- a/bicep/infra/main.parameters.dev.bicepparam
+++ b/bicep/infra/main.parameters.dev.bicepparam
@@ -39,8 +39,8 @@ param enableAIModelInference = true
 // Azure Managed Redis (AMR)
 param enableManagedRedis = true
 param redisPublicNetworkAccess = 'Disabled'
-param redisSkuName = 'Balanced_B10'
-param redisSkuCapacity = 2
+param redisSkuName = 'Balanced_B0'
+param redisSkuCapacity = 1
 
 // No Entra ID auth in dev (simplifies testing)
 param entraAuth = false


### PR DESCRIPTION
## Summary
This PR reduces the Azure Managed Redis SKU used in the Dev environment to lower infrastructure costs.

## Changes
- Updated `main.parameters.dev.bicepparam`
- Changed Azure Managed Redis SKU:
  - From: `Balanced_B10`
  - To: `Balanced_B0`
- Reduced instance count:
  - From: **2 instances**
  - To: **1 instance**

## Reason for Change
The previous configuration (`Balanced_B10` with 2 instances) is unnecessarily large for Dev workloads and contributes significantly to the overall solution cost.

The Dev environment does not require the higher compute or memory capacity provided by the larger SKU or multiple instances. Using `Balanced_B0` with a single instance provides sufficient capacity for development and testing scenarios while optimizing cost.

## Impact
- Reduces infrastructure cost for Dev deployments
- No expected functional impact for development or testing workflows
