### PR TITLE
feat: update retired models to gpt-4.1-mini and gpt-4.1

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -264,7 +264,7 @@ param openAiInstances object = {
         name: 'chat'
         model: {
           format: 'OpenAI'
-          name: 'gpt-4-1-mini'
+          name: 'gpt-4.1-mini'
           version: '2025-04-14'
         }
         sku: {
@@ -286,10 +286,10 @@ param openAiInstances object = {
         }
       }
       {
-        name: 'gpt-4-1'
+        name: 'gpt-4.1'
         model: {
           format: 'OpenAI'
-          name: 'gpt-4-1'
+          name: 'gpt-4.1'
           version: '2025-04-14'
         }
         sku: {
@@ -307,7 +307,7 @@ param openAiInstances object = {
         name: 'chat'
         model: {
           format: 'OpenAI'
-          name: 'gpt-4-1-mini'
+          name: 'gpt-4.1-mini'
           version: '2025-04-14'
         }
         sku: {
@@ -326,7 +326,7 @@ param openAiInstances object = {
         name: 'chat'
         model: {
           format: 'OpenAI'
-          name: 'gpt-4-1-mini'
+          name: 'gpt-4.1-mini'
           version: '2025-04-14'
         }
         sku: {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -264,8 +264,8 @@ param openAiInstances object = {
         name: 'chat'
         model: {
           format: 'OpenAI'
-          name: 'gpt-4o-mini'
-          version: '2024-07-18'
+          name: 'gpt-4-1-mini'
+          version: '2025-04-14'
         }
         sku: {
           name: 'Standard'
@@ -286,11 +286,11 @@ param openAiInstances object = {
         }
       }
       {
-        name: 'gpt-4o'
+        name: 'gpt-4-1'
         model: {
           format: 'OpenAI'
-          name: 'gpt-4o'
-          version: '2024-05-13'
+          name: 'gpt-4-1'
+          version: '2025-04-14'
         }
         sku: {
           name: 'GlobalStandard'
@@ -307,8 +307,8 @@ param openAiInstances object = {
         name: 'chat'
         model: {
           format: 'OpenAI'
-          name: 'gpt-4o-mini'
-          version: '2024-07-18'
+          name: 'gpt-4-1-mini'
+          version: '2025-04-14'
         }
         sku: {
           name: 'Standard'
@@ -326,8 +326,8 @@ param openAiInstances object = {
         name: 'chat'
         model: {
           format: 'OpenAI'
-          name: 'gpt-4o-mini'
-          version: '2024-07-18'
+          name: 'gpt-4-1-mini'
+          version: '2025-04-14'
         }
         sku: {
           name: 'Standard'

--- a/infra/modules/apim/policies/hr_pii_product_policy.xml
+++ b/infra/modules/apim/policies/hr_pii_product_policy.xml
@@ -8,7 +8,7 @@
 
         <!-- Restrict access for this product to specific models -->
         <choose>
-            <when condition="@(!new [] { "gpt-4o", "embedding" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
+            <when condition="@(!new [] { "gpt-4-1", "embedding" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
                 <return-response>
                     <set-status code="401" reason="Unauthorized model access" />
                 </return-response>
@@ -18,7 +18,7 @@
         <!-- Adding content safety with customized option for the product -->
         <!-- Only enforce content safety for specific deployments that handle user-generated content -->
         <choose>
-            <when condition="@(new [] { "gpt-4o" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
+            <when condition="@(new [] { "gpt-4-1" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
                 <!-- Failure to pass content safety will result in 403 error -->
                 <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
                     <categories output-type="EightSeverityLevels">
@@ -32,7 +32,7 @@
         <!-- Capacity management - Subscription Level: allow only assigned tpm for each HR use case subscription -->
         <set-variable name="target-deployment" value="@((string)context.Request.MatchedParameters["deployment-id"])" />
         <choose>
-            <when condition="@((string)context.Variables["target-deployment"] == "gpt-4o")">
+            <when condition="@((string)context.Variables["target-deployment"] == "gpt-4-1")">
                 <azure-openai-token-limit 
                     counter-key="@(context.Subscription.Id + "-" + context.Variables["target-deployment"])" 
                     tokens-per-minute="10000" 

--- a/infra/modules/apim/policies/hr_pii_product_policy.xml
+++ b/infra/modules/apim/policies/hr_pii_product_policy.xml
@@ -8,7 +8,7 @@
 
         <!-- Restrict access for this product to specific models -->
         <choose>
-            <when condition="@(!new [] { "gpt-4-1", "embedding" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
+            <when condition="@(!new [] { "gpt-4.1", "embedding" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
                 <return-response>
                     <set-status code="401" reason="Unauthorized model access" />
                 </return-response>
@@ -18,7 +18,7 @@
         <!-- Adding content safety with customized option for the product -->
         <!-- Only enforce content safety for specific deployments that handle user-generated content -->
         <choose>
-            <when condition="@(new [] { "gpt-4-1" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
+            <when condition="@(new [] { "gpt-4.1" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
                 <!-- Failure to pass content safety will result in 403 error -->
                 <llm-content-safety backend-id="content-safety-backend" shield-prompt="true">
                     <categories output-type="EightSeverityLevels">
@@ -32,7 +32,7 @@
         <!-- Capacity management - Subscription Level: allow only assigned tpm for each HR use case subscription -->
         <set-variable name="target-deployment" value="@((string)context.Request.MatchedParameters["deployment-id"])" />
         <choose>
-            <when condition="@((string)context.Variables["target-deployment"] == "gpt-4-1")">
+            <when condition="@((string)context.Variables["target-deployment"] == "gpt-4.1")">
                 <azure-openai-token-limit 
                     counter-key="@(context.Subscription.Id + "-" + context.Variables["target-deployment"])" 
                     tokens-per-minute="10000" 

--- a/infra/modules/apim/policies/hr_product_policy.xml
+++ b/infra/modules/apim/policies/hr_product_policy.xml
@@ -4,7 +4,7 @@
         <!-- Capacity management - Subscription Level: allow only assigned tpm for each HR use case subscription -->
         <set-variable name="target-deployment" value="@((string)context.Request.MatchedParameters["deployment-id"])" />
         <choose>
-            <when condition="@((string)context.Variables["target-deployment"] == "gpt-4o")">
+            <when condition="@((string)context.Variables["target-deployment"] == "gpt-4-1")">
                 <azure-openai-token-limit 
                     counter-key="@(context.Subscription.Id + "-" + context.Variables["target-deployment"])" 
                     tokens-per-minute="10000" 

--- a/infra/modules/apim/policies/hr_product_policy.xml
+++ b/infra/modules/apim/policies/hr_product_policy.xml
@@ -4,7 +4,7 @@
         <!-- Capacity management - Subscription Level: allow only assigned tpm for each HR use case subscription -->
         <set-variable name="target-deployment" value="@((string)context.Request.MatchedParameters["deployment-id"])" />
         <choose>
-            <when condition="@((string)context.Variables["target-deployment"] == "gpt-4-1")">
+            <when condition="@((string)context.Variables["target-deployment"] == "gpt-4.1")">
                 <azure-openai-token-limit 
                     counter-key="@(context.Subscription.Id + "-" + context.Variables["target-deployment"])" 
                     tokens-per-minute="10000" 

--- a/infra/modules/apim/policies/openai_api_policy.xml
+++ b/infra/modules/apim/policies/openai_api_policy.xml
@@ -102,7 +102,7 @@
 
                             clusters.Add(new JObject()
                             {
-                                { "deploymentName", "gpt-4-1" },
+                                { "deploymentName", "gpt-4.1" },
                                 { "routes", new JArray(routes[0]) }
                             });
                             

--- a/infra/modules/apim/policies/openai_api_policy.xml
+++ b/infra/modules/apim/policies/openai_api_policy.xml
@@ -102,7 +102,7 @@
 
                             clusters.Add(new JObject()
                             {
-                                { "deploymentName", "gpt-4o" },
+                                { "deploymentName", "gpt-4-1" },
                                 { "routes", new JArray(routes[0]) }
                             });
                             

--- a/infra/modules/apim/policies/openai_api_policy_dynamic_throttling.xml
+++ b/infra/modules/apim/policies/openai_api_policy_dynamic_throttling.xml
@@ -92,7 +92,7 @@
 
                             clusters.Add(new JObject()
                             {
-                                { "deploymentName", "gpt-4o" },
+                                { "deploymentName", "gpt-4-1" },
                                 { "routes", new JArray(routes[0]) }
                             });
 

--- a/infra/modules/apim/policies/openai_api_policy_dynamic_throttling.xml
+++ b/infra/modules/apim/policies/openai_api_policy_dynamic_throttling.xml
@@ -92,7 +92,7 @@
 
                             clusters.Add(new JObject()
                             {
-                                { "deploymentName", "gpt-4-1" },
+                                { "deploymentName", "gpt-4.1" },
                                 { "routes", new JArray(routes[0]) }
                             });
 

--- a/infra/modules/apim/policies/retail_product_policy.xml
+++ b/infra/modules/apim/policies/retail_product_policy.xml
@@ -3,7 +3,7 @@
         <base />
         <!-- Restrict access for this product to specific models -->
         <choose>
-            <when condition="@(!new [] { "gpt-4-1", "chat", "embedding" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
+            <when condition="@(!new [] { "gpt-4.1", "chat", "embedding" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
                 <return-response>
                     <set-status code="401" reason="Unauthorized model access" />
                 </return-response>

--- a/infra/modules/apim/policies/retail_product_policy.xml
+++ b/infra/modules/apim/policies/retail_product_policy.xml
@@ -3,7 +3,7 @@
         <base />
         <!-- Restrict access for this product to specific models -->
         <choose>
-            <when condition="@(!new [] { "gpt-4o", "chat", "embedding" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
+            <when condition="@(!new [] { "gpt-4-1", "chat", "embedding" }.Contains(context.Request.MatchedParameters["deployment-id"] ?? String.Empty))">
                 <return-response>
                     <set-status code="401" reason="Unauthorized model access" />
                 </return-response>

--- a/src/testing/openai-testing.http
+++ b/src/testing/openai-testing.http
@@ -2,7 +2,7 @@
 @aiHRSubscriptionKey = ""
 @aiRetailSubscriptionKey = ""
 
-### gpt-4-1-mini/AI-HR
+### gpt-4.1-mini/AI-HR
 POST {{aiHubGatewayOpenAIBaseUrl}}/chat/chat/completions?api-version=2024-06-01
 Content-Type: application/json
 api-key: {{aiHRSubscriptionKey}}
@@ -15,8 +15,8 @@ api-key: {{aiHRSubscriptionKey}}
   "stream": true
 }
 
-### gpt-4-1/AI-HR
-POST {{aiHubGatewayOpenAIBaseUrl}}/gpt-4-1/chat/completions?api-version=2024-06-01
+### gpt-4.1/AI-HR
+POST {{aiHubGatewayOpenAIBaseUrl}}/gpt-4.1/chat/completions?api-version=2024-06-01
 Content-Type: application/json
 api-key: {{aiHRSubscriptionKey}}
 
@@ -28,7 +28,7 @@ api-key: {{aiHRSubscriptionKey}}
   "stream": false
 }
 
-### gpt-4-1-mini/AI-Retail
+### gpt-4.1-mini/AI-Retail
 POST {{aiHubGatewayOpenAIBaseUrl}}/chat/chat/completions?api-version=2024-06-01
 Content-Type: application/json
 api-key: {{aiRetailSubscriptionKey}}

--- a/src/testing/openai-testing.http
+++ b/src/testing/openai-testing.http
@@ -2,7 +2,7 @@
 @aiHRSubscriptionKey = ""
 @aiRetailSubscriptionKey = ""
 
-### gpt-35-turbo/AI-HR
+### gpt-4-1-mini/AI-HR
 POST {{aiHubGatewayOpenAIBaseUrl}}/chat/chat/completions?api-version=2024-06-01
 Content-Type: application/json
 api-key: {{aiHRSubscriptionKey}}
@@ -15,8 +15,8 @@ api-key: {{aiHRSubscriptionKey}}
   "stream": true
 }
 
-### gpt-4o/AI-HR
-POST {{aiHubGatewayOpenAIBaseUrl}}/gpt-4o/chat/completions?api-version=2024-06-01
+### gpt-4-1/AI-HR
+POST {{aiHubGatewayOpenAIBaseUrl}}/gpt-4-1/chat/completions?api-version=2024-06-01
 Content-Type: application/json
 api-key: {{aiHRSubscriptionKey}}
 
@@ -28,7 +28,7 @@ api-key: {{aiHRSubscriptionKey}}
   "stream": false
 }
 
-### gpt-35-turbo/AI-Retail
+### gpt-4-1-mini/AI-Retail
 POST {{aiHubGatewayOpenAIBaseUrl}}/chat/chat/completions?api-version=2024-06-01
 Content-Type: application/json
 api-key: {{aiRetailSubscriptionKey}}

--- a/src/usage-reports/model-pricing.json
+++ b/src/usage-reports/model-pricing.json
@@ -14,7 +14,7 @@
     },
     {
         "id": "2",
-        "model": "gpt-4-1-mini",
+        "model": "gpt-4.1-mini",
         "deploymentName": "chat",
         "isActive": true,
         "CostPerInputUnit": 0.15,
@@ -27,8 +27,8 @@
     },
     {
         "id": "3",
-        "model": "gpt-4-1",
-        "deploymentName": "gpt-4-1",
+        "model": "gpt-4.1",
+        "deploymentName": "gpt-4.1",
         "isActive": true,
         "CostPerInputUnit": 0.03,
         "CostPerOutputUnit": 0.06,
@@ -40,8 +40,8 @@
     },
     {
         "id": "4",
-        "model": "gpt-4-1",
-        "deploymentName": "gpt-4-1",
+        "model": "gpt-4.1",
+        "deploymentName": "gpt-4.1",
         "isActive": true,
         "CostPerInputUnit": 0.005,
         "CostPerOutputUnit": 0.015,

--- a/src/usage-reports/model-pricing.json
+++ b/src/usage-reports/model-pricing.json
@@ -14,7 +14,7 @@
     },
     {
         "id": "2",
-        "model": "gpt-4o-mini",
+        "model": "gpt-4-1-mini",
         "deploymentName": "chat",
         "isActive": true,
         "CostPerInputUnit": 0.15,
@@ -27,8 +27,8 @@
     },
     {
         "id": "3",
-        "model": "gpt-4",
-        "deploymentName": "gpt-4",
+        "model": "gpt-4-1",
+        "deploymentName": "gpt-4-1",
         "isActive": true,
         "CostPerInputUnit": 0.03,
         "CostPerOutputUnit": 0.06,
@@ -40,8 +40,8 @@
     },
     {
         "id": "4",
-        "model": "gpt-4o",
-        "deploymentName": "gpt-4o",
+        "model": "gpt-4-1",
+        "deploymentName": "gpt-4-1",
         "isActive": true,
         "CostPerInputUnit": 0.005,
         "CostPerOutputUnit": 0.015,

--- a/src/usage-reports/usage-record.json
+++ b/src/usage-reports/usage-record.json
@@ -5,7 +5,7 @@
     "subscriptionId": "master",
     "productName": "AI-Retail",
     "targetService": "chat.completion",
-    "model": "gpt-35-turbo",
+    "model": "gpt-4-1-mini",
     "gatewayName": "APIM-HOST.azure-api.net",
     "gatewayRegion": "East US",
     "aiGatewayId": "managed",

--- a/src/usage-reports/usage-record.json
+++ b/src/usage-reports/usage-record.json
@@ -5,7 +5,7 @@
     "subscriptionId": "master",
     "productName": "AI-Retail",
     "targetService": "chat.completion",
-    "model": "gpt-4-1-mini",
+    "model": "gpt-4.1-mini",
     "gatewayName": "APIM-HOST.azure-api.net",
     "gatewayRegion": "East US",
     "aiGatewayId": "managed",


### PR DESCRIPTION
## Summary

Update all references from retired GPT models to the latest **gpt-4.1-mini** and **gpt-4.1** models (using dot notation as per OpenAI naming convention).

## Changes

- **bicep/infra/main.bicep** – Updated model deployment names and versions
- **APIM policies** – Updated model references in routing/throttling policies (`hr_pii_product_policy.xml`, `hr_product_policy.xml`, `openai_api_policy.xml`, `openai_api_policy_dynamic_throttling.xml`, `retail_product_policy.xml`)
- **src/testing/openai-testing.http** – Updated test requests to use new model names
- **src/usage-reports/model-pricing.json** – Updated pricing entries for new models
- **src/usage-reports/usage-record.json** – Updated sample usage record

## Commits

1. `feat: update retired models to gpt-4-1-mini and gpt-4-1` – Initial model name update
2. `fix: correct model names to gpt-4.1-mini and gpt-4.1 (dot notation)` – Corrected to official dot notation