### PR TITLE
Change path matching to use StartsWith for base-path

### DIFF
--- a/bicep/infra/modules/apim/policies/frag-request-processor.xml
+++ b/bicep/infra/modules/apim/policies/frag-request-processor.xml
@@ -61,7 +61,7 @@
                     var match = context.Variables.GetValueOrDefault<JObject>("config-api-types")?.Children<JProperty>()
                         .FirstOrDefault(a => {
                             var basePath = a.Value["base-path"]?.ToString();
-                            return !String.IsNullOrEmpty(basePath) && path.Contains(basePath);
+                            return !String.IsNullOrEmpty(basePath) && path.StartsWith(basePath, StringComparison.OrdinalIgnoreCase);
                         });
                     return match?.Name ?? String.Empty;
                 } catch { return String.Empty; }


### PR DESCRIPTION
Addresses issue #109 

Changed base-path matching from Contains to StartsWith so that an api-type is only selected when the request path begins with the configured base-path, preventing false matches where the base-path appears mid-URL.