### PR TITLE
docs: add Agent Governance Toolkit integration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 🏰 Citadel Governance Hub
+# ≡ƒÅ░ Citadel Governance Hub
 
 <div align="center">
     <img src="./assets/citadel-logo-v2.PNG" alt="Citadel Logo" width="120" style="margin-bottom: 10px;">
@@ -10,7 +10,7 @@
 
 ---
 
-## 🚀 Overview
+## ≡ƒÜÇ Overview
 
 Citadel Governance Hub is an **enterprise-grade AI landing zone** that provides a centralized, governable, and observable control plane for AI consumption across teams and environments.
 
@@ -21,27 +21,27 @@ This repository is a **solution accelerator** that helps you deploy and operate 
 - Usage ingestion components (Logic Apps + Azure Functions)
 - Validation notebooks and operational guides
 
-## 🏛️ Part of the Foundry Citadel Platform
+## ≡ƒÅ¢∩╕Å Part of the Foundry Citadel Platform
 
 > [!IMPORTANT]
-> This accelerator is the **reference implementation of Layer 1 – Governance Hub** in the [AI Citadel Platform](https://aka.ms/foundry-citadel) layered security architecture.
+> This accelerator is the **reference implementation of Layer 1 ΓÇô Governance Hub** in the [AI Citadel Platform](https://aka.ms/foundry-citadel) layered security architecture.
 
 The **AI Citadel Platform** is a unified, layered approach to AI security and compliance, designed to enable enterprises to scale AI innovation while maintaining trust, security, and regulatory alignment. The platform is composed of four interlocking layers:
 
 | Layer | Name | Responsibility | Implementation |
 |-------|------|----------------|----------------|
-| 🔷 **Layer 1** | **Governance Hub** | Runtime enforcement — unified AI gateway, policy-as-code, identity validation, token rate limiting, content filtering, cost attribution | **👉 This Accelerator** ([aka.ms/ai-hub-gateway](https://aka.ms/ai-hub-gateway)) |
-| 🔶 **Layer 2** | **AI Control Plane** | Observability & compliance — agent traces, AI evaluations, fleet operations, automated compliance checks | [Microsoft Foundry Control Plane](https://learn.microsoft.com/en-us/azure/ai-foundry/control-plane/overview) |
-| 🟢 **Layer 3** | **Agent Identity (Agent 365)** | Agent identity & lifecycle — unique agent identities, shadow agent detection, sponsorship model, access packages | [Governing Agent Identities with Entra ID](https://learn.microsoft.com/en-us/entra/id-governance/agent-id-governance-overview) |
-| 🛡️ **Layer 4** | **Security Fabric** | Unified protection — Microsoft Defender threat intelligence, Purview data governance, Entra access control | Microsoft Defender, Purview & Entra |
+| ≡ƒö╖ **Layer 1** | **Governance Hub** | Runtime enforcement ΓÇö unified AI gateway, policy-as-code, identity validation, token rate limiting, content filtering, cost attribution | **≡ƒæë This Accelerator** ([aka.ms/ai-hub-gateway](https://aka.ms/ai-hub-gateway)) |
+| ≡ƒö╢ **Layer 2** | **AI Control Plane** | Observability & compliance ΓÇö agent traces, AI evaluations, fleet operations, automated compliance checks | [Microsoft Foundry Control Plane](https://learn.microsoft.com/en-us/azure/ai-foundry/control-plane/overview) |
+| ≡ƒƒó **Layer 3** | **Agent Identity (Agent 365)** | Agent identity & lifecycle ΓÇö unique agent identities, shadow agent detection, sponsorship model, access packages | [Governing Agent Identities with Entra ID](https://learn.microsoft.com/en-us/entra/id-governance/agent-id-governance-overview) |
+| ≡ƒ¢í∩╕Å **Layer 4** | **Security Fabric** | Unified protection ΓÇö Microsoft Defender threat intelligence, Purview data governance, Entra access control | Microsoft Defender, Purview & Entra |
 
-The layers are not isolated silos — they form an integrated architecture grounded in the principle of **separation of concerns with unified oversight**. Layer 1 (this accelerator) acts as the physical gateway through a hub-and-spoke deployment where a centrally managed AI gateway (Azure API Management) enforces runtime policies, while spoke environments give each business unit autonomous development within guardrails.
+The layers are not isolated silos ΓÇö they form an integrated architecture grounded in the principle of **separation of concerns with unified oversight**. Layer 1 (this accelerator) acts as the physical gateway through a hub-and-spoke deployment where a centrally managed AI gateway (Azure API Management) enforces runtime policies, while spoke environments give each business unit autonomous development within guardrails.
 
-> 📎 For the full Citadel Platform approach and guidance, visit: [aka.ms/foundry-citadel](https://aka.ms/foundry-citadel)
+> ≡ƒôÄ For the full Citadel Platform approach and guidance, visit: [aka.ms/foundry-citadel](https://aka.ms/foundry-citadel)
 
 ---
 
-## 🌟 Benefits (Summary)
+## ≡ƒîƒ Benefits (Summary)
 
 Citadel Governance Hub helps you standardize AI governance while maintaining developer velocity:
 
@@ -53,7 +53,7 @@ For a detailed stakeholder- and capability-level breakdown, see [Governance Hub 
 
 ---
 
-## 🧩 What's in This Repo
+## ≡ƒº⌐ What's in This Repo
 
 At a high level, the accelerator includes:
 
@@ -62,7 +62,7 @@ At a high level, the accelerator includes:
 - [validation](./validation): Jupyter notebooks for post-deployment validation and onboarding.
 - [guides](./guides): operational and architecture documentation.
 
-## 🏗️ Architecture Overview
+## ≡ƒÅù∩╕Å Architecture Overview
 
 AI Citadel Governance Hub follows a **hub-spoke architecture** that integrates seamlessly with your existing enterprise Azure Landing Zone:
 
@@ -88,7 +88,7 @@ Agentic workloads in other spokes are routed first to the hub network firewall t
 
 This provides an additional layer of isolation for AI workloads while still enabling secure communication with other enterprise resources in the hub.
 
-### 🎯 **Citadel Governance Hub** - Central Control Plane
+### ≡ƒÄ» **Citadel Governance Hub** - Central Control Plane
 
 The central governance layer with unified AI Gateway that all AI workloads route through.
 
@@ -96,15 +96,15 @@ The central governance layer with unified AI Gateway that all AI workloads route
 
 | Component | Purpose | Enterprise Features |
 |-----------|---------|---------------------|
-| **🚪 API Management** | Unified AI gateway | LLM governance, AI resiliency, AI registry gateway |
-| **📘 API Center** | Universal AI Registry | Discovery of available AI tools, agents and AI services |
-| **🔍 Microsoft Foundry** | Control Plane/Models/Observability | Platform LLMs, Control Plane & AI Evaluations |
-| **📊 Log Analytics** | Logs, metrics & audits | Scalable enterprise telemetry ingestion and storage |
-| **📊 Application Insights** | Platform monitoring | Performance dashboards, automated alerts |
-| **📨 Event Hub** | Usage data streaming | Real-time usage streaming, custom logging |
-| **🗄️ Cosmos DB** | Usage analytics | Long-term storage of usage, automatic scaling |
-| **⚡ Logic App** | Event processing | Workflow-based processing of usage/logs & AI Eval |
-| **🔗 Virtual Network** | Private connectivity | BYO-VNET support, private endpoints |
+| **≡ƒÜ¬ API Management** | Unified AI gateway | LLM governance, AI resiliency, AI registry gateway |
+| **≡ƒôÿ API Center** | Universal AI Registry | Discovery of available AI tools, agents and AI services |
+| **≡ƒöì Microsoft Foundry** | Control Plane/Models/Observability | Platform LLMs, Control Plane & AI Evaluations |
+| **≡ƒôè Log Analytics** | Logs, metrics & audits | Scalable enterprise telemetry ingestion and storage |
+| **≡ƒôè Application Insights** | Platform monitoring | Performance dashboards, automated alerts |
+| **≡ƒô¿ Event Hub** | Usage data streaming | Real-time usage streaming, custom logging |
+| **≡ƒùä∩╕Å Cosmos DB** | Usage analytics | Long-term storage of usage, automatic scaling |
+| **ΓÜí Logic App** | Event processing | Workflow-based processing of usage/logs & AI Eval |
+| **≡ƒöù Virtual Network** | Private connectivity | BYO-VNET support, private endpoints |
 
 #### Security & Compliance
 
@@ -112,10 +112,10 @@ AI Gateway security & compliance enforcements components:
 
 | Component | Purpose |Enterprise Features |
 |---------|---------|---------------------|
-| **🔐 Managed Identity** | Zero-credential auth | Secure service-to-service communication |
-| **🛡️ Content Safety** | LLM protection | Prompt Shield and Content Safety protections |
-| **💳 Language Service** | PII detection | Natural language and RegEx based PII entity detection with anonymization support |
-| **🔍 Microsoft Foundry** | Control Plane | Control plane, responsible AI, registration of external agents  |
+| **≡ƒöÉ Managed Identity** | Zero-credential auth | Secure service-to-service communication |
+| **≡ƒ¢í∩╕Å Content Safety** | LLM protection | Prompt Shield and Content Safety protections |
+| **≡ƒÆ│ Language Service** | PII detection | Natural language and RegEx based PII entity detection with anonymization support |
+| **≡ƒöì Microsoft Foundry** | Control Plane | Control plane, responsible AI, registration of external agents  |
 
 Supported by subscription wide security services:
 
@@ -141,7 +141,7 @@ Pluggable components to enhance AI Citadel Governance capabilities:
 |-----------|---------|
 | **Azure Managed Redis** | Semantic caching layer for high-throughput AI workloads |
 
-### 🌐 **Citadel Compliant Agents** - Existing and new agents on-boarding
+### ≡ƒîÉ **Citadel Compliant Agents** - Existing and new agents on-boarding
 
 To govern AI agents through AI Citadel Governance Hub, agents must communicate with AI backends (central LLMs, tools and agents) through the Citadel's unified AI gateway.
 
@@ -173,18 +173,18 @@ For detailed guidance, see [AI App Landing Zone Repo](https://github.com/Azure/A
 
 ---
 
-## 🔄 AI Citadel Contracts - Connect agents to governance hub
+## ≡ƒöä AI Citadel Contracts - Connect agents to governance hub
 
 Citadel Governance Hub seamlessly integrates with **Citadel compliant Agents** environments through automated governance alignment:
 
-### 📝 **AI Access Contract**
-Declares the governed dependencies an agent needs—LLMs, AI services, tools, and reusable agents—along with precise access policies:
+### ≡ƒô¥ **AI Access Contract**
+Declares the governed dependencies an agent needsΓÇöLLMs, AI services, tools, and reusable agentsΓÇöalong with precise access policies:
 - Model selection and capacity allocation
 - Regional preferences and compliance requirements
 - Safety and security guardrails (content safety, PII handling, OAuth scopes,...)
 - Usage quotas and cost limits
 
-### 📤 **AI Publish Contract**
+### ≡ƒôñ **AI Publish Contract**
 Describes the tools and agents a spoke exposes back to the hub:
 - Publishing rules and governance gates
 - Ownership metadata and documentation
@@ -194,16 +194,16 @@ Describes the tools and agents a spoke exposes back to the hub:
 >NOTE: Publish contracts are upcoming and will be available in future releases.
 
 **Benefits:**
-- ✅ Audit-ready traceability through infrastructure-as-code
-- ✅ Faster release cycles with automated approvals
-- ✅ Reduced manual effort in governance onboarding
-- ✅ Continuous policy compliance verification
+- Γ£à Audit-ready traceability through infrastructure-as-code
+- Γ£à Faster release cycles with automated approvals
+- Γ£à Reduced manual effort in governance onboarding
+- Γ£à Continuous policy compliance verification
 
-> 🔗 **Learn More:** [AI Citadel Access Contracts Guide](./bicep/infra/citadel-access-contracts/README.md)
+> ≡ƒöù **Learn More:** [AI Citadel Access Contracts Guide](./bicep/infra/citadel-access-contracts/README.md)
 
 ---
 
-## 📋 Prerequisites
+## ≡ƒôï Prerequisites
 
 **Azure Requirements:**
 - **Azure CLI** and **Azure Developer CLI** installed and signed in
@@ -219,7 +219,7 @@ Although it is recommended to have the below tools installed on a local machine 
 
 ---
 
-## 🚀 Quick Deploy
+## ≡ƒÜÇ Quick Deploy
 
 Deploy your Citadel Governance Hub in minutes with Azure Developer CLI:
 
@@ -234,13 +234,13 @@ azd init --template Azure-Samples/ai-hub-gateway-solution-accelerator -e ai-hub-
 azd up
 ```
 
-> 💡 **Tip**: Use Azure Cloud Shell to avoid local setup. Review [main.bicep](./bicep/infra/main.bicep) and [main.bicepparam](./bicep/infra/main.bicepparam) configuration before deployment.
+> ≡ƒÆí **Tip**: Use Azure Cloud Shell to avoid local setup. Review [main.bicep](./bicep/infra/main.bicep) and [main.bicepparam](./bicep/infra/main.bicepparam) configuration before deployment.
 
-### ✅ Post-Deployment Validation
+### Γ£à Post-Deployment Validation
 
 After successful deployment, validate your Citadel Governance Hub setup using our interactive notebooks.
 
-### 🧪 Validation Notebooks
+### ≡ƒº¬ Validation Notebooks
 
 Use the following interactive Jupyter notebooks to validate and configure your Citadel Governance Hub deployment:
 
@@ -253,88 +253,89 @@ Use the following interactive Jupyter notebooks to validate and configure your C
 | [**Citadel JWT Authentication Tests**](./validation/citadel-jwt-authentication-tests.ipynb) | Validate JWT-based authentication and app role authorization across all LLM API endpoints, including dual auth flows and negative testing. |
 | [**Citadel Unified AI API Tests**](./validation/citadel-unified-ai-api-tests.ipynb) | Validate the Unified AI Wildcard API across different model providers (Azure OpenAI, Foundry, Gemini) and API patterns with load testing. |
 
-> 💡 **Tip**: These notebooks require Python with the `openai`, `requests`, and `matplotlib` among other packages highlighted in [requirements.txt](./validation/requirements.txt). Ensure you have configured your environment variables before running.
+> ≡ƒÆí **Tip**: These notebooks require Python with the `openai`, `requests`, and `matplotlib` among other packages highlighted in [requirements.txt](./validation/requirements.txt). Ensure you have configured your environment variables before running.
 
 ---
 
-## 📚 Comprehensive Documentation
+## ≡ƒôÜ Comprehensive Documentation
 
 Master AI Citadel Governance Hub implementation and operations with our detailed guides:
 
-### 📖 **Concepts & Benefits**
+### ≡ƒôû **Concepts & Benefits**
 
 | Guide | Description |
 |-------|-------------|
-| [**🆕 Governance Hub Benefits**](./guides/governance-hub-benefits.md) | Detailed benefits and stakeholder value of adopting Citadel Governance Hub |
-| [**🆕 Citadel Sizing Guide**](./guides/citadel-sizing-guide.md) | Guidance on sizing the Citadel Governance Hub based on workloads and environments |
-| [**🆕 PTU Estimation Guide**](./guides/put-estimation-guide.md) | Azure OpenAI / Foundry LLM sizing guide for PTU vs Pay-as-you-Go capacity planning |
+| [**≡ƒåò Governance Hub Benefits**](./guides/governance-hub-benefits.md) | Detailed benefits and stakeholder value of adopting Citadel Governance Hub |
+| [**≡ƒåò Citadel Sizing Guide**](./guides/citadel-sizing-guide.md) | Guidance on sizing the Citadel Governance Hub based on workloads and environments |
+| [**≡ƒåò PTU Estimation Guide**](./guides/put-estimation-guide.md) | Azure OpenAI / Foundry LLM sizing guide for PTU vs Pay-as-you-Go capacity planning |
 
-### 🏗️ **Landing zone deployment**
-
-| Guide | Description |
-|-------|-------------|
-| [**🆕 Quick Deployment Guide**](./guides/quick-deployment-guide.md) | Fast deployment for non-production environments |
-| [**🆕 Full Deployment Guide**](./guides/full-deployment-guide.md) | Comprehensive guide for dev, staging, and production |
-| [**🆕 Parameters Deployment Guide**](./guides/parameters-usage-guide.md) | Comprehensive Bicep parameter file usage |
-| [**🆕 Network Approach Guide**](./guides/network-approach.md) | Detailed networking approach for Citadel Governance Hub deployment |
-
-### 🔧 **AI Service Integration**
+### ≡ƒÅù∩╕Å **Landing zone deployment**
 
 | Guide | Description |
 |-------|-------------|
-| [**🆕 LLM Backend Onboarding Guide**](./bicep/infra/llm-backend-onboarding/README.md) | Independent LLM backend routing deployment with load balancing and failover |
-| [**🆕 APIM Gateway Upgrade Guide**](./bicep/infra/apim-gateway-upgrade/README.md) | Update gateway policies, APIs, backends, diagnostics, and named values on an existing APIM instance without re-provisioning infrastructure |
+| [**≡ƒåò Quick Deployment Guide**](./guides/quick-deployment-guide.md) | Fast deployment for non-production environments |
+| [**≡ƒåò Full Deployment Guide**](./guides/full-deployment-guide.md) | Comprehensive guide for dev, staging, and production |
+| [**≡ƒåò Parameters Deployment Guide**](./guides/parameters-usage-guide.md) | Comprehensive Bicep parameter file usage |
+| [**≡ƒåò Network Approach Guide**](./guides/network-approach.md) | Detailed networking approach for Citadel Governance Hub deployment |
 
-### 🔧 **Use-case Onboarding**
-
-| Guide | Description |
-|-------|-------------|
-| [**🆕 AI Citadel Access Contracts Guide**](./bicep/infra/citadel-access-contracts/README.md) | Guide on integrating new/existing AI apps & agents with AI Citadel Governance Hub |
-| [**🆕 AI Citadel Access Contracts Policies**](./bicep/infra/citadel-access-contracts/citadel-access-contracts-policy.md) | Deep dive into policy configurations for AI Citadel Access Contracts |
-
-
-### 🛡️ **Security & Compliance**
+### ≡ƒöº **AI Service Integration**
 
 | Guide | Description |
 |-------|-------------|
-| [**🆕 PII Detection & Masking**](./guides/pii-masking-apim.md) | Automated sensitive data protection |
-| [**🆕 Entra ID Authentication**](./guides/entraid-auth-validation.md) | JWT validation and Zero Trust implementation |
-| [**🆕 JWT Client Identity & Permissions**](./guides/jwt-client-identity-permissions.md) | Configure client app identities, group-based access management, and permissions for JWT-protected endpoints |
+| [**≡ƒåò LLM Backend Onboarding Guide**](./bicep/infra/llm-backend-onboarding/README.md) | Independent LLM backend routing deployment with load balancing and failover |
+| [**≡ƒåò APIM Gateway Upgrade Guide**](./bicep/infra/apim-gateway-upgrade/README.md) | Update gateway policies, APIs, backends, diagnostics, and named values on an existing APIM instance without re-provisioning infrastructure |
 
-### 📊 **Observability & Analytics**
-
-| Guide | Description |
-|-------|-------------|
-| [**🆕 Power BI Dashboard**](./guides/power-bi-dashboard.md) | Usage analytics and cost allocation dashboards |
-
-### 🏗️ **Architecture & configurations**
+### ≡ƒöº **Use-case Onboarding**
 
 | Guide | Description |
 |-------|-------------|
-| [**🆕 LLM Routing Architecture**](./guides/llm-routing-architecture.md) | Technical dive into LLM model and backend routing logic |
-| [**🆕 LLM Backend Onboarding Guide**](./guides/LLM-Backend-Onboarding-Guide.md) | How to onboard LLM backends (Azure OpenAI, Foundry, external providers) with dynamic routing and load balancing |
-| [**🆕 Throttling Events Handling**](./guides/throttling-events-handling.md) | Monitor and handle throttling events per use case, deployment, and other dimensions |
+| [**≡ƒåò AI Citadel Access Contracts Guide**](./bicep/infra/citadel-access-contracts/README.md) | Guide on integrating new/existing AI apps & agents with AI Citadel Governance Hub |
+| [**≡ƒåò AI Citadel Access Contracts Policies**](./bicep/infra/citadel-access-contracts/citadel-access-contracts-policy.md) | Deep dive into policy configurations for AI Citadel Access Contracts |
+
+
+### ≡ƒ¢í∩╕Å **Security & Compliance**
+
+| Guide | Description |
+|-------|-------------|
+| [**≡ƒåò PII Detection & Masking**](./guides/pii-masking-apim.md) | Automated sensitive data protection |
+| [**≡ƒåò Entra ID Authentication**](./guides/entraid-auth-validation.md) | JWT validation and Zero Trust implementation |
+| [**≡ƒåò JWT Client Identity & Permissions**](./guides/jwt-client-identity-permissions.md) | Configure client app identities, group-based access management, and permissions for JWT-protected endpoints |
+| [**≡ƒåò Agent Governance Toolkit Integration**](./guides/agent-governance-toolkit-integration.md) | Add agent-level governance (per-action policies, trust scoring, audit logging) alongside gateway controls |
+
+### ≡ƒôè **Observability & Analytics**
+
+| Guide | Description |
+|-------|-------------|
+| [**≡ƒåò Power BI Dashboard**](./guides/power-bi-dashboard.md) | Usage analytics and cost allocation dashboards |
+
+### ≡ƒÅù∩╕Å **Architecture & configurations**
+
+| Guide | Description |
+|-------|-------------|
+| [**≡ƒåò LLM Routing Architecture**](./guides/llm-routing-architecture.md) | Technical dive into LLM model and backend routing logic |
+| [**≡ƒåò LLM Backend Onboarding Guide**](./guides/LLM-Backend-Onboarding-Guide.md) | How to onboard LLM backends (Azure OpenAI, Foundry, external providers) with dynamic routing and load balancing |
+| [**≡ƒåò Throttling Events Handling**](./guides/throttling-events-handling.md) | Monitor and handle throttling events per use case, deployment, and other dimensions |
 
 ---
 
-## 🤝 Contributing
+## ≡ƒñ¥ Contributing
 
 We welcome contributions from the community! Whether it's:
-- 🐛 Bug reports and fixes
-- 📖 Documentation improvements
-- 💡 Feature requests and enhancements
+- ≡ƒÉ¢ Bug reports and fixes
+- ≡ƒôû Documentation improvements
+- ≡ƒÆí Feature requests and enhancements
 
 Please see our [Contributing Guide](./CONTRIBUTING.md) for details.
 
 ---
 
-## 📞 Support & Community
+## ≡ƒô₧ Support & Community
 
-- **🐛 Issues**: [GitHub Issues](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/issues)
+- **≡ƒÉ¢ Issues**: [GitHub Issues](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/issues)
 
 ---
 
-## 📄 License
+## ≡ƒôä License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
@@ -346,6 +347,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 *Providing protection, structure, and strength as you scale new heights with enterprise AI*
 
-[🚀 Deploy Now](./guides/quick-deployment-guide.md) | [📚 Documentation](./guides/) | [🤝 Contribute](#-contributing)
+[≡ƒÜÇ Deploy Now](./guides/quick-deployment-guide.md) | [≡ƒôÜ Documentation](./guides/) | [≡ƒñ¥ Contribute](#-contributing)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ≡ƒÅ░ Citadel Governance Hub
+# 🏰 Citadel Governance Hub
 
 <div align="center">
     <img src="./assets/citadel-logo-v2.PNG" alt="Citadel Logo" width="120" style="margin-bottom: 10px;">
@@ -10,7 +10,7 @@
 
 ---
 
-## ≡ƒÜÇ Overview
+## 🚀 Overview
 
 Citadel Governance Hub is an **enterprise-grade AI landing zone** that provides a centralized, governable, and observable control plane for AI consumption across teams and environments.
 
@@ -21,27 +21,27 @@ This repository is a **solution accelerator** that helps you deploy and operate 
 - Usage ingestion components (Logic Apps + Azure Functions)
 - Validation notebooks and operational guides
 
-## ≡ƒÅ¢∩╕Å Part of the Foundry Citadel Platform
+## 🏛️ Part of the Foundry Citadel Platform
 
 > [!IMPORTANT]
-> This accelerator is the **reference implementation of Layer 1 ΓÇô Governance Hub** in the [AI Citadel Platform](https://aka.ms/foundry-citadel) layered security architecture.
+> This accelerator is the **reference implementation of Layer 1 – Governance Hub** in the [AI Citadel Platform](https://aka.ms/foundry-citadel) layered security architecture.
 
 The **AI Citadel Platform** is a unified, layered approach to AI security and compliance, designed to enable enterprises to scale AI innovation while maintaining trust, security, and regulatory alignment. The platform is composed of four interlocking layers:
 
 | Layer | Name | Responsibility | Implementation |
 |-------|------|----------------|----------------|
-| ≡ƒö╖ **Layer 1** | **Governance Hub** | Runtime enforcement ΓÇö unified AI gateway, policy-as-code, identity validation, token rate limiting, content filtering, cost attribution | **≡ƒæë This Accelerator** ([aka.ms/ai-hub-gateway](https://aka.ms/ai-hub-gateway)) |
-| ≡ƒö╢ **Layer 2** | **AI Control Plane** | Observability & compliance ΓÇö agent traces, AI evaluations, fleet operations, automated compliance checks | [Microsoft Foundry Control Plane](https://learn.microsoft.com/en-us/azure/ai-foundry/control-plane/overview) |
-| ≡ƒƒó **Layer 3** | **Agent Identity (Agent 365)** | Agent identity & lifecycle ΓÇö unique agent identities, shadow agent detection, sponsorship model, access packages | [Governing Agent Identities with Entra ID](https://learn.microsoft.com/en-us/entra/id-governance/agent-id-governance-overview) |
-| ≡ƒ¢í∩╕Å **Layer 4** | **Security Fabric** | Unified protection ΓÇö Microsoft Defender threat intelligence, Purview data governance, Entra access control | Microsoft Defender, Purview & Entra |
+| 🔷 **Layer 1** | **Governance Hub** | Runtime enforcement — unified AI gateway, policy-as-code, identity validation, token rate limiting, content filtering, cost attribution | **👉 This Accelerator** ([aka.ms/ai-hub-gateway](https://aka.ms/ai-hub-gateway)) |
+| 🔶 **Layer 2** | **AI Control Plane** | Observability & compliance — agent traces, AI evaluations, fleet operations, automated compliance checks | [Microsoft Foundry Control Plane](https://learn.microsoft.com/en-us/azure/ai-foundry/control-plane/overview) |
+| 🟢 **Layer 3** | **Agent Identity (Agent 365)** | Agent identity & lifecycle — unique agent identities, shadow agent detection, sponsorship model, access packages | [Governing Agent Identities with Entra ID](https://learn.microsoft.com/en-us/entra/id-governance/agent-id-governance-overview) |
+| 🛡️ **Layer 4** | **Security Fabric** | Unified protection — Microsoft Defender threat intelligence, Purview data governance, Entra access control | Microsoft Defender, Purview & Entra |
 
-The layers are not isolated silos ΓÇö they form an integrated architecture grounded in the principle of **separation of concerns with unified oversight**. Layer 1 (this accelerator) acts as the physical gateway through a hub-and-spoke deployment where a centrally managed AI gateway (Azure API Management) enforces runtime policies, while spoke environments give each business unit autonomous development within guardrails.
+The layers are not isolated silos — they form an integrated architecture grounded in the principle of **separation of concerns with unified oversight**. Layer 1 (this accelerator) acts as the physical gateway through a hub-and-spoke deployment where a centrally managed AI gateway (Azure API Management) enforces runtime policies, while spoke environments give each business unit autonomous development within guardrails.
 
-> ≡ƒôÄ For the full Citadel Platform approach and guidance, visit: [aka.ms/foundry-citadel](https://aka.ms/foundry-citadel)
+> 📎 For the full Citadel Platform approach and guidance, visit: [aka.ms/foundry-citadel](https://aka.ms/foundry-citadel)
 
 ---
 
-## ≡ƒîƒ Benefits (Summary)
+## 🌟 Benefits (Summary)
 
 Citadel Governance Hub helps you standardize AI governance while maintaining developer velocity:
 
@@ -53,7 +53,7 @@ For a detailed stakeholder- and capability-level breakdown, see [Governance Hub 
 
 ---
 
-## ≡ƒº⌐ What's in This Repo
+## 🧩 What's in This Repo
 
 At a high level, the accelerator includes:
 
@@ -62,7 +62,7 @@ At a high level, the accelerator includes:
 - [validation](./validation): Jupyter notebooks for post-deployment validation and onboarding.
 - [guides](./guides): operational and architecture documentation.
 
-## ≡ƒÅù∩╕Å Architecture Overview
+## 🏗️ Architecture Overview
 
 AI Citadel Governance Hub follows a **hub-spoke architecture** that integrates seamlessly with your existing enterprise Azure Landing Zone:
 
@@ -88,7 +88,7 @@ Agentic workloads in other spokes are routed first to the hub network firewall t
 
 This provides an additional layer of isolation for AI workloads while still enabling secure communication with other enterprise resources in the hub.
 
-### ≡ƒÄ» **Citadel Governance Hub** - Central Control Plane
+### 🎯 **Citadel Governance Hub** - Central Control Plane
 
 The central governance layer with unified AI Gateway that all AI workloads route through.
 
@@ -96,15 +96,15 @@ The central governance layer with unified AI Gateway that all AI workloads route
 
 | Component | Purpose | Enterprise Features |
 |-----------|---------|---------------------|
-| **≡ƒÜ¬ API Management** | Unified AI gateway | LLM governance, AI resiliency, AI registry gateway |
-| **≡ƒôÿ API Center** | Universal AI Registry | Discovery of available AI tools, agents and AI services |
-| **≡ƒöì Microsoft Foundry** | Control Plane/Models/Observability | Platform LLMs, Control Plane & AI Evaluations |
-| **≡ƒôè Log Analytics** | Logs, metrics & audits | Scalable enterprise telemetry ingestion and storage |
-| **≡ƒôè Application Insights** | Platform monitoring | Performance dashboards, automated alerts |
-| **≡ƒô¿ Event Hub** | Usage data streaming | Real-time usage streaming, custom logging |
-| **≡ƒùä∩╕Å Cosmos DB** | Usage analytics | Long-term storage of usage, automatic scaling |
-| **ΓÜí Logic App** | Event processing | Workflow-based processing of usage/logs & AI Eval |
-| **≡ƒöù Virtual Network** | Private connectivity | BYO-VNET support, private endpoints |
+| **🚪 API Management** | Unified AI gateway | LLM governance, AI resiliency, AI registry gateway |
+| **📘 API Center** | Universal AI Registry | Discovery of available AI tools, agents and AI services |
+| **🔍 Microsoft Foundry** | Control Plane/Models/Observability | Platform LLMs, Control Plane & AI Evaluations |
+| **📊 Log Analytics** | Logs, metrics & audits | Scalable enterprise telemetry ingestion and storage |
+| **📊 Application Insights** | Platform monitoring | Performance dashboards, automated alerts |
+| **📨 Event Hub** | Usage data streaming | Real-time usage streaming, custom logging |
+| **🗄️ Cosmos DB** | Usage analytics | Long-term storage of usage, automatic scaling |
+| **⚡ Logic App** | Event processing | Workflow-based processing of usage/logs & AI Eval |
+| **🔗 Virtual Network** | Private connectivity | BYO-VNET support, private endpoints |
 
 #### Security & Compliance
 
@@ -112,10 +112,10 @@ AI Gateway security & compliance enforcements components:
 
 | Component | Purpose |Enterprise Features |
 |---------|---------|---------------------|
-| **≡ƒöÉ Managed Identity** | Zero-credential auth | Secure service-to-service communication |
-| **≡ƒ¢í∩╕Å Content Safety** | LLM protection | Prompt Shield and Content Safety protections |
-| **≡ƒÆ│ Language Service** | PII detection | Natural language and RegEx based PII entity detection with anonymization support |
-| **≡ƒöì Microsoft Foundry** | Control Plane | Control plane, responsible AI, registration of external agents  |
+| **🔐 Managed Identity** | Zero-credential auth | Secure service-to-service communication |
+| **🛡️ Content Safety** | LLM protection | Prompt Shield and Content Safety protections |
+| **💳 Language Service** | PII detection | Natural language and RegEx based PII entity detection with anonymization support |
+| **🔍 Microsoft Foundry** | Control Plane | Control plane, responsible AI, registration of external agents  |
 
 Supported by subscription wide security services:
 
@@ -141,7 +141,7 @@ Pluggable components to enhance AI Citadel Governance capabilities:
 |-----------|---------|
 | **Azure Managed Redis** | Semantic caching layer for high-throughput AI workloads |
 
-### ≡ƒîÉ **Citadel Compliant Agents** - Existing and new agents on-boarding
+### 🌐 **Citadel Compliant Agents** - Existing and new agents on-boarding
 
 To govern AI agents through AI Citadel Governance Hub, agents must communicate with AI backends (central LLMs, tools and agents) through the Citadel's unified AI gateway.
 
@@ -173,18 +173,18 @@ For detailed guidance, see [AI App Landing Zone Repo](https://github.com/Azure/A
 
 ---
 
-## ≡ƒöä AI Citadel Contracts - Connect agents to governance hub
+## 🔄 AI Citadel Contracts - Connect agents to governance hub
 
 Citadel Governance Hub seamlessly integrates with **Citadel compliant Agents** environments through automated governance alignment:
 
-### ≡ƒô¥ **AI Access Contract**
-Declares the governed dependencies an agent needsΓÇöLLMs, AI services, tools, and reusable agentsΓÇöalong with precise access policies:
+### 📝 **AI Access Contract**
+Declares the governed dependencies an agent needs—LLMs, AI services, tools, and reusable agents—along with precise access policies:
 - Model selection and capacity allocation
 - Regional preferences and compliance requirements
 - Safety and security guardrails (content safety, PII handling, OAuth scopes,...)
 - Usage quotas and cost limits
 
-### ≡ƒôñ **AI Publish Contract**
+### 📤 **AI Publish Contract**
 Describes the tools and agents a spoke exposes back to the hub:
 - Publishing rules and governance gates
 - Ownership metadata and documentation
@@ -194,16 +194,16 @@ Describes the tools and agents a spoke exposes back to the hub:
 >NOTE: Publish contracts are upcoming and will be available in future releases.
 
 **Benefits:**
-- Γ£à Audit-ready traceability through infrastructure-as-code
-- Γ£à Faster release cycles with automated approvals
-- Γ£à Reduced manual effort in governance onboarding
-- Γ£à Continuous policy compliance verification
+- ✅ Audit-ready traceability through infrastructure-as-code
+- ✅ Faster release cycles with automated approvals
+- ✅ Reduced manual effort in governance onboarding
+- ✅ Continuous policy compliance verification
 
-> ≡ƒöù **Learn More:** [AI Citadel Access Contracts Guide](./bicep/infra/citadel-access-contracts/README.md)
+> 🔗 **Learn More:** [AI Citadel Access Contracts Guide](./bicep/infra/citadel-access-contracts/README.md)
 
 ---
 
-## ≡ƒôï Prerequisites
+## 📋 Prerequisites
 
 **Azure Requirements:**
 - **Azure CLI** and **Azure Developer CLI** installed and signed in
@@ -219,7 +219,7 @@ Although it is recommended to have the below tools installed on a local machine 
 
 ---
 
-## ≡ƒÜÇ Quick Deploy
+## 🚀 Quick Deploy
 
 Deploy your Citadel Governance Hub in minutes with Azure Developer CLI:
 
@@ -234,13 +234,13 @@ azd init --template Azure-Samples/ai-hub-gateway-solution-accelerator -e ai-hub-
 azd up
 ```
 
-> ≡ƒÆí **Tip**: Use Azure Cloud Shell to avoid local setup. Review [main.bicep](./bicep/infra/main.bicep) and [main.bicepparam](./bicep/infra/main.bicepparam) configuration before deployment.
+> 💡 **Tip**: Use Azure Cloud Shell to avoid local setup. Review [main.bicep](./bicep/infra/main.bicep) and [main.bicepparam](./bicep/infra/main.bicepparam) configuration before deployment.
 
-### Γ£à Post-Deployment Validation
+### ✅ Post-Deployment Validation
 
 After successful deployment, validate your Citadel Governance Hub setup using our interactive notebooks.
 
-### ≡ƒº¬ Validation Notebooks
+### 🧪 Validation Notebooks
 
 Use the following interactive Jupyter notebooks to validate and configure your Citadel Governance Hub deployment:
 
@@ -253,89 +253,89 @@ Use the following interactive Jupyter notebooks to validate and configure your C
 | [**Citadel JWT Authentication Tests**](./validation/citadel-jwt-authentication-tests.ipynb) | Validate JWT-based authentication and app role authorization across all LLM API endpoints, including dual auth flows and negative testing. |
 | [**Citadel Unified AI API Tests**](./validation/citadel-unified-ai-api-tests.ipynb) | Validate the Unified AI Wildcard API across different model providers (Azure OpenAI, Foundry, Gemini) and API patterns with load testing. |
 
-> ≡ƒÆí **Tip**: These notebooks require Python with the `openai`, `requests`, and `matplotlib` among other packages highlighted in [requirements.txt](./validation/requirements.txt). Ensure you have configured your environment variables before running.
+> 💡 **Tip**: These notebooks require Python with the `openai`, `requests`, and `matplotlib` among other packages highlighted in [requirements.txt](./validation/requirements.txt). Ensure you have configured your environment variables before running.
 
 ---
 
-## ≡ƒôÜ Comprehensive Documentation
+## 📚 Comprehensive Documentation
 
 Master AI Citadel Governance Hub implementation and operations with our detailed guides:
 
-### ≡ƒôû **Concepts & Benefits**
+### 📖 **Concepts & Benefits**
 
 | Guide | Description |
 |-------|-------------|
-| [**≡ƒåò Governance Hub Benefits**](./guides/governance-hub-benefits.md) | Detailed benefits and stakeholder value of adopting Citadel Governance Hub |
-| [**≡ƒåò Citadel Sizing Guide**](./guides/citadel-sizing-guide.md) | Guidance on sizing the Citadel Governance Hub based on workloads and environments |
-| [**≡ƒåò PTU Estimation Guide**](./guides/put-estimation-guide.md) | Azure OpenAI / Foundry LLM sizing guide for PTU vs Pay-as-you-Go capacity planning |
+| [**🆕 Governance Hub Benefits**](./guides/governance-hub-benefits.md) | Detailed benefits and stakeholder value of adopting Citadel Governance Hub |
+| [**🆕 Citadel Sizing Guide**](./guides/citadel-sizing-guide.md) | Guidance on sizing the Citadel Governance Hub based on workloads and environments |
+| [**🆕 PTU Estimation Guide**](./guides/put-estimation-guide.md) | Azure OpenAI / Foundry LLM sizing guide for PTU vs Pay-as-you-Go capacity planning |
 
-### ≡ƒÅù∩╕Å **Landing zone deployment**
-
-| Guide | Description |
-|-------|-------------|
-| [**≡ƒåò Quick Deployment Guide**](./guides/quick-deployment-guide.md) | Fast deployment for non-production environments |
-| [**≡ƒåò Full Deployment Guide**](./guides/full-deployment-guide.md) | Comprehensive guide for dev, staging, and production |
-| [**≡ƒåò Parameters Deployment Guide**](./guides/parameters-usage-guide.md) | Comprehensive Bicep parameter file usage |
-| [**≡ƒåò Network Approach Guide**](./guides/network-approach.md) | Detailed networking approach for Citadel Governance Hub deployment |
-
-### ≡ƒöº **AI Service Integration**
+### 🏗️ **Landing zone deployment**
 
 | Guide | Description |
 |-------|-------------|
-| [**≡ƒåò LLM Backend Onboarding Guide**](./bicep/infra/llm-backend-onboarding/README.md) | Independent LLM backend routing deployment with load balancing and failover |
-| [**≡ƒåò APIM Gateway Upgrade Guide**](./bicep/infra/apim-gateway-upgrade/README.md) | Update gateway policies, APIs, backends, diagnostics, and named values on an existing APIM instance without re-provisioning infrastructure |
+| [**🆕 Quick Deployment Guide**](./guides/quick-deployment-guide.md) | Fast deployment for non-production environments |
+| [**🆕 Full Deployment Guide**](./guides/full-deployment-guide.md) | Comprehensive guide for dev, staging, and production |
+| [**🆕 Parameters Deployment Guide**](./guides/parameters-usage-guide.md) | Comprehensive Bicep parameter file usage |
+| [**🆕 Network Approach Guide**](./guides/network-approach.md) | Detailed networking approach for Citadel Governance Hub deployment |
 
-### ≡ƒöº **Use-case Onboarding**
-
-| Guide | Description |
-|-------|-------------|
-| [**≡ƒåò AI Citadel Access Contracts Guide**](./bicep/infra/citadel-access-contracts/README.md) | Guide on integrating new/existing AI apps & agents with AI Citadel Governance Hub |
-| [**≡ƒåò AI Citadel Access Contracts Policies**](./bicep/infra/citadel-access-contracts/citadel-access-contracts-policy.md) | Deep dive into policy configurations for AI Citadel Access Contracts |
-
-
-### ≡ƒ¢í∩╕Å **Security & Compliance**
+### 🔧 **AI Service Integration**
 
 | Guide | Description |
 |-------|-------------|
-| [**≡ƒåò PII Detection & Masking**](./guides/pii-masking-apim.md) | Automated sensitive data protection |
-| [**≡ƒåò Entra ID Authentication**](./guides/entraid-auth-validation.md) | JWT validation and Zero Trust implementation |
-| [**≡ƒåò JWT Client Identity & Permissions**](./guides/jwt-client-identity-permissions.md) | Configure client app identities, group-based access management, and permissions for JWT-protected endpoints |
-| [**≡ƒåò Agent Governance Toolkit Integration**](./guides/agent-governance-toolkit-integration.md) | Add agent-level governance (per-action policies, trust scoring, audit logging) alongside gateway controls |
+| [**🆕 LLM Backend Onboarding Guide**](./bicep/infra/llm-backend-onboarding/README.md) | Independent LLM backend routing deployment with load balancing and failover |
+| [**🆕 APIM Gateway Upgrade Guide**](./bicep/infra/apim-gateway-upgrade/README.md) | Update gateway policies, APIs, backends, diagnostics, and named values on an existing APIM instance without re-provisioning infrastructure |
 
-### ≡ƒôè **Observability & Analytics**
+### 🔧 **Use-case Onboarding**
 
 | Guide | Description |
 |-------|-------------|
-| [**≡ƒåò Power BI Dashboard**](./guides/power-bi-dashboard.md) | Usage analytics and cost allocation dashboards |
+| [**🆕 AI Citadel Access Contracts Guide**](./bicep/infra/citadel-access-contracts/README.md) | Guide on integrating new/existing AI apps & agents with AI Citadel Governance Hub |
+| [**🆕 AI Citadel Access Contracts Policies**](./bicep/infra/citadel-access-contracts/citadel-access-contracts-policy.md) | Deep dive into policy configurations for AI Citadel Access Contracts |
 
-### ≡ƒÅù∩╕Å **Architecture & configurations**
+
+### 🛡️ **Security & Compliance**
 
 | Guide | Description |
 |-------|-------------|
-| [**≡ƒåò LLM Routing Architecture**](./guides/llm-routing-architecture.md) | Technical dive into LLM model and backend routing logic |
-| [**≡ƒåò LLM Backend Onboarding Guide**](./guides/LLM-Backend-Onboarding-Guide.md) | How to onboard LLM backends (Azure OpenAI, Foundry, external providers) with dynamic routing and load balancing |
-| [**≡ƒåò Throttling Events Handling**](./guides/throttling-events-handling.md) | Monitor and handle throttling events per use case, deployment, and other dimensions |
+| [**🆕 PII Detection & Masking**](./guides/pii-masking-apim.md) | Automated sensitive data protection |
+| [**🆕 Entra ID Authentication**](./guides/entraid-auth-validation.md) | JWT validation and Zero Trust implementation |
+| [**🆕 JWT Client Identity & Permissions**](./guides/jwt-client-identity-permissions.md) | Configure client app identities, group-based access management, and permissions for JWT-protected endpoints |
+| [**🆕 Agent Governance Toolkit Integration**](./guides/agent-governance-toolkit-integration.md) | Add agent-level governance (per-action policies, trust scoring, audit logging) alongside gateway controls |
+
+### 📊 **Observability & Analytics**
+
+| Guide | Description |
+|-------|-------------|
+| [**🆕 Power BI Dashboard**](./guides/power-bi-dashboard.md) | Usage analytics and cost allocation dashboards |
+
+### 🏗️ **Architecture & configurations**
+
+| Guide | Description |
+|-------|-------------|
+| [**🆕 LLM Routing Architecture**](./guides/llm-routing-architecture.md) | Technical dive into LLM model and backend routing logic |
+| [**🆕 LLM Backend Onboarding Guide**](./guides/LLM-Backend-Onboarding-Guide.md) | How to onboard LLM backends (Azure OpenAI, Foundry, external providers) with dynamic routing and load balancing |
+| [**🆕 Throttling Events Handling**](./guides/throttling-events-handling.md) | Monitor and handle throttling events per use case, deployment, and other dimensions |
 
 ---
 
-## ≡ƒñ¥ Contributing
+## 🤝 Contributing
 
 We welcome contributions from the community! Whether it's:
-- ≡ƒÉ¢ Bug reports and fixes
-- ≡ƒôû Documentation improvements
-- ≡ƒÆí Feature requests and enhancements
+- 🐛 Bug reports and fixes
+- 📖 Documentation improvements
+- 💡 Feature requests and enhancements
 
 Please see our [Contributing Guide](./CONTRIBUTING.md) for details.
 
 ---
 
-## ≡ƒô₧ Support & Community
+## 📞 Support & Community
 
-- **≡ƒÉ¢ Issues**: [GitHub Issues](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/issues)
+- **🐛 Issues**: [GitHub Issues](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/issues)
 
 ---
 
-## ≡ƒôä License
+## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
@@ -347,6 +347,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 *Providing protection, structure, and strength as you scale new heights with enterprise AI*
 
-[≡ƒÜÇ Deploy Now](./guides/quick-deployment-guide.md) | [≡ƒôÜ Documentation](./guides/) | [≡ƒñ¥ Contribute](#-contributing)
+[🚀 Deploy Now](./guides/quick-deployment-guide.md) | [📚 Documentation](./guides/) | [🤝 Contribute](#-contributing)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -300,7 +300,6 @@ Master AI Citadel Governance Hub implementation and operations with our detailed
 | [**🆕 PII Detection & Masking**](./guides/pii-masking-apim.md) | Automated sensitive data protection |
 | [**🆕 Entra ID Authentication**](./guides/entraid-auth-validation.md) | JWT validation and Zero Trust implementation |
 | [**🆕 JWT Client Identity & Permissions**](./guides/jwt-client-identity-permissions.md) | Configure client app identities, group-based access management, and permissions for JWT-protected endpoints |
-| [**🆕 Agent Governance Toolkit Integration**](./guides/agent-governance-toolkit-integration.md) | Add agent-level governance (per-action policies, trust scoring, audit logging) alongside gateway controls |
 
 ### 📊 **Observability & Analytics**
 

--- a/guides/agent-governance-toolkit-integration.md
+++ b/guides/agent-governance-toolkit-integration.md
@@ -1,0 +1,192 @@
+# Agent Governance Toolkit (AGT) Integration Guide
+
+This guide explains how to integrate the [Agent Governance Toolkit (AGT)](https://github.com/microsoft/agent-governance-toolkit) with Citadel Governance Hub to add **agent-level governance** on top of gateway-level controls.
+
+- For Citadel deployment, see the [Quick Deployment Guide](./quick-deployment-guide.md).
+- For Access Contract setup, see the [Access Contracts README](../bicep/infra/citadel-access-contracts/README.md).
+- For the full platform architecture, see [Foundry Citadel Platform](https://aka.ms/foundry-citadel).
+
+---
+
+## Why Integrate AGT with Citadel?
+
+Citadel Governance Hub governs the **infrastructure perimeter**: which models, tools, and agents can be accessed, at what rate, with what safety filters. This is essential, but insufficient for production agent deployments.
+
+AGT governs the **agent behavior itself**: what actions the agent takes, whether it follows its policies, trust relationships between agents, and tamper-evident audit logging. These are complementary enforcement boundaries.
+
+| Concern | Citadel (Gateway) | AGT (Agent Runtime) |
+|---------|-------------------|---------------------|
+| **Enforcement point** | APIM gateway (centralized) | Agent runtime library (local) |
+| **Latency** | Network hop through gateway | Sub-millisecond in-process |
+| **Policy granularity** | Rate limits, content filters, quotas | Per-action allow/deny, caller restrictions |
+| **Identity** | Entra ID / subscription keys | Ed25519 / SPIFFE cryptographic identity |
+| **Trust model** | Binary (authenticated or not) | Continuous scoring (0-1000) |
+
+Together, they provide defense-in-depth: Citadel enforces coarse-grained rules at the perimeter, AGT enforces fine-grained rules at the agent.
+
+---
+
+## How AGT Maps to Citadel's 4 Layers
+
+AGT is not confined to a single Citadel layer. It provides capabilities across the architecture:
+
+### Layer 1: Governance Hub
+
+Citadel Access Contracts can reference **AGT policy bundles** that are injected into agent environments at deployment time. The gateway enforces infrastructure policies (rate limits, content safety, JWT validation). AGT enforces agent-level policies (action restrictions, justification requirements, caller ACLs) inside the runtime.
+
+**Policy precedence**: Gateway rules are evaluated first. AGT rules are evaluated second. Both must pass for an action to proceed.
+
+### Layer 2: AI Control Plane
+
+AGT exports governance telemetry (policy decisions, trust score changes, action interceptions) to Azure Event Hub and Application Insights via the `CitadelAuditExporter`. These events include **correlation IDs** linking AGT decisions to APIM request traces and Foundry execution traces, enabling unified observability dashboards.
+
+### Layer 3: Agent Identity
+
+Entra ID / Agent 365 remains the authoritative source for enterprise agent identity. AGT's Ed25519/SPIFFE identities handle runtime cryptographic credentials. The integration is **federation**: AGT trust scores surface as risk labels in telemetry, not as primary Entra metadata.
+
+### Layer 4: Security Fabric
+
+AGT's `data_classification` labels align with Purview sensitivity labels. AGT trust scores can surface as risk signals in Defender for AI through the telemetry pipeline.
+
+---
+
+## Integration Architecture
+
+```
+Agent Runtime (Spoke)                Citadel Hub                    Azure Monitor
+┌──────────────────────┐            ┌──────────────────┐          ┌──────────────┐
+│                      │            │                  │          │              │
+│  Agent Application   │   LLM     │  APIM Gateway    │          │  App Insights│
+│  ┌────────────────┐  │  request  │  ┌────────────┐  │          │              │
+│  │ AGT Policy     ├──┼──────────►│  │ Rate Limit │──┼────►LLM  │  Event Hub   │
+│  │ Engine         │  │           │  │ Content    │  │          │              │
+│  │                │  │           │  │ JWT Auth   │  │          │  Log         │
+│  │ allow/deny     │  │           │  └────────────┘  │          │  Analytics   │
+│  └──────┬─────────┘  │           └──────────────────┘          └──────┬───────┘
+│         │            │                                                │
+│  ┌──────▼─────────┐  │           ┌──────────────────┐                │
+│  │ Citadel Audit  ├──┼──────────►│  Event Hub /      │────────────────┘
+│  │ Exporter       │  │  events   │  App Insights     │
+│  └────────────────┘  │           └──────────────────┘
+└──────────────────────┘
+```
+
+---
+
+## Getting Started
+
+### 1. Install AGT in your agent environment
+
+```bash
+pip install agent-governance-toolkit
+```
+
+### 2. Configure the Citadel audit exporter
+
+Set the following environment variables in your agent spoke:
+
+```bash
+# Required for audit export
+export CITADEL_EVENTHUB_CONNECTION_STRING="Endpoint=sb://..."
+export CITADEL_APPINSIGHTS_CONNECTION_STRING="InstrumentationKey=..."
+
+# Optional
+export CITADEL_EVENTHUB_NAME="agt-governance-events"
+export CITADEL_EXPORT_BATCH_SIZE="50"
+```
+
+### 3. Load a policy bundle
+
+AGT policy bundles define agent-level governance rules. They can be loaded from a file, Azure Key Vault, or a URL:
+
+```python
+from agent_os.integrations.citadel import PolicyBundleResolver
+
+resolver = PolicyBundleResolver()
+
+# From a local file (development)
+bundle = resolver.resolve_from_file("policies/agent-policy.yaml")
+
+# From Key Vault (production, referenced by Access Contract)
+bundle = resolver.resolve_from_keyvault(
+    vault_url="https://myvault.vault.azure.net",
+    secret_name="agt-policy-bundle-customer-support",
+)
+```
+
+### 4. Export governance events
+
+```python
+from agent_os.exporters import CitadelAuditExporter
+from agent_os.exporters.citadel_exporter import (
+    GovernanceEvent,
+    GovernanceEventType,
+    Decision,
+    CorrelationContext,
+)
+
+exporter = CitadelAuditExporter.from_env()
+
+event = GovernanceEvent(
+    event_type=GovernanceEventType.POLICY_DECISION,
+    agent_id="customer-support-agent-01",
+    action="query_customer_database",
+    decision=Decision.ALLOW,
+    policy_name="customer-support-policy",
+    trust_score=800,
+    correlation=CorrelationContext(
+        apim_request_id="abc-123",  # From APIM response header
+        agt_decision_id="def-456",
+    ),
+)
+
+exporter.export_event(event)
+await exporter.flush()
+```
+
+---
+
+## Access Contract Integration
+
+Citadel Access Contracts can reference an AGT policy bundle so that governance policies are automatically provisioned alongside infrastructure access. See the [sample access contract](https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/citadel-governed-agent/sample-access-contract) in the AGT repository for an example.
+
+---
+
+## Coverage Boundaries
+
+Understanding what each system handles avoids duplication:
+
+| Concern | Handled By |
+|---------|-----------|
+| LLM model access control | Citadel Layer 1 (APIM products/subscriptions) |
+| Token rate limiting | Citadel Layer 1 (APIM policies) |
+| Content safety filtering | Citadel Layer 1 (Azure Content Safety) |
+| PII detection at gateway | Citadel Layer 1 (Azure Language Service) |
+| Per-action policy evaluation | AGT Policy Engine |
+| Tool call allow/deny | AGT Capability Model |
+| Agent-to-agent trust | AGT Trust Layer (Ed25519, SPIFFE) |
+| Trust scoring (0-1000) | AGT AgentMesh |
+| Tamper-evident audit logs | AGT Audit System |
+| Fleet observability | Citadel Layer 2 + AGT Exporter |
+| Agent enterprise identity | Citadel Layer 3 (Entra) |
+| Threat detection | Citadel Layer 4 (Defender) |
+| Data governance labels | Citadel Layer 4 (Purview) + AGT data_classification |
+
+---
+
+## Failure Modes
+
+| Component Unavailable | Behavior |
+|----------------------|----------|
+| Azure Event Hub / App Insights | AGT continues operating. Events queue locally and retry. |
+| Citadel APIM Gateway | Agent cannot reach LLM/tools. AGT policy engine still works locally. |
+| AGT Policy Engine | Agent actions proceed ungoverned (configurable fail-open/fail-closed). |
+
+---
+
+## References
+
+- [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit): Full documentation and source
+- [AGT + Citadel Integration Architecture](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/integrations/citadel-integration.md): Detailed architecture reference
+- [End-to-End Example](https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/citadel-governed-agent): Working example with mock mode
+- [Foundry Citadel Platform](https://aka.ms/foundry-citadel): Full 4-layer architecture

--- a/guides/agent-governance-toolkit-integration.md
+++ b/guides/agent-governance-toolkit-integration.md
@@ -2,51 +2,64 @@
 
 This guide explains how to integrate the [Agent Governance Toolkit (AGT)](https://github.com/microsoft/agent-governance-toolkit) with Citadel Governance Hub to add **agent-level governance** on top of gateway-level controls.
 
-- For Citadel deployment, see the [Quick Deployment Guide](./quick-deployment-guide.md).
-- For Access Contract setup, see the [Access Contracts README](../bicep/infra/citadel-access-contracts/README.md).
-- For the full platform architecture, see [Foundry Citadel Platform](https://aka.ms/foundry-citadel).
+**Related guides:**
+- [Quick Deployment Guide](./quick-deployment-guide.md): Deploy Citadel Governance Hub
+- [Access Contracts README](../bicep/infra/citadel-access-contracts/README.md): Configure agent-to-hub contracts
+- [Foundry Citadel Platform](https://aka.ms/foundry-citadel): Full 4-layer architecture overview
 
 ---
 
 ## Why Integrate AGT with Citadel?
 
-Citadel Governance Hub governs the **infrastructure perimeter**: which models, tools, and agents can be accessed, at what rate, with what safety filters. This is essential, but insufficient for production agent deployments.
+Citadel Governance Hub governs the **infrastructure perimeter**: which models, tools, and agents can be accessed, at what rate, with what safety filters. This is essential, but insufficient for production agent deployments where agents make dozens of tool calls per interaction.
 
-AGT governs the **agent behavior itself**: what actions the agent takes, whether it follows its policies, trust relationships between agents, and tamper-evident audit logging. These are complementary enforcement boundaries.
+AGT governs the **agent behavior itself**: what actions the agent takes, whether it follows its policies, trust relationships between agents, and tamper-evident audit logging. These are complementary enforcement boundaries, not competing approaches.
+
+**Use AGT alongside Citadel when you need:**
+- Per-action tool call allow/deny inside the agent runtime (not just at the gateway)
+- Continuous trust scoring (0-1000) that adapts based on agent behavior
+- Cryptographic agent identity (Ed25519 / SPIFFE) for inter-agent trust
+- Tamper-evident audit logs with hash-chain evidence preservation
 
 | Concern | Citadel (Gateway) | AGT (Agent Runtime) |
 |---------|-------------------|---------------------|
-| **Enforcement point** | APIM gateway (centralized) | Agent runtime library (local) |
-| **Latency** | Network hop through gateway | Sub-millisecond in-process |
-| **Policy granularity** | Rate limits, content filters, quotas | Per-action allow/deny, caller restrictions |
+| **Enforcement point** | APIM gateway (centralized) | Agent runtime library (in-process) |
+| **Latency** | Network hop through gateway | Sub-millisecond (<0.1 ms per evaluation) |
+| **Policy granularity** | Rate limits, content filters, quotas | Per-action allow/deny, caller restrictions, justification requirements |
 | **Identity** | Entra ID / subscription keys | Ed25519 / SPIFFE cryptographic identity |
-| **Trust model** | Binary (authenticated or not) | Continuous scoring (0-1000) |
+| **Trust model** | Binary (authenticated or not) | Continuous scoring (0-1000) with automatic credential revocation |
+| **Audit** | APIM request logs | Hash-chain tamper-evident governance events |
 
-Together, they provide defense-in-depth: Citadel enforces coarse-grained rules at the perimeter, AGT enforces fine-grained rules at the agent.
+Together, they provide defense-in-depth: Citadel enforces coarse-grained rules at the perimeter, AGT enforces fine-grained rules at the agent. Both must pass for an action to proceed.
 
 ---
 
 ## How AGT Maps to Citadel's 4 Layers
 
-AGT is not confined to a single Citadel layer. It provides capabilities across the architecture:
+AGT is not confined to a single Citadel layer. It provides capabilities that complement each layer:
 
 ### Layer 1: Governance Hub
 
-Citadel Access Contracts can reference **AGT policy bundles** that are injected into agent environments at deployment time. The gateway enforces infrastructure policies (rate limits, content safety, JWT validation). AGT enforces agent-level policies (action restrictions, justification requirements, caller ACLs) inside the runtime.
+[Citadel Access Contracts](../bicep/infra/citadel-access-contracts/README.md) can reference **AGT policy bundles** that are loaded into agent environments at deployment time. The gateway enforces infrastructure policies (rate limits, content safety, JWT validation). AGT enforces agent-level policies (action restrictions, justification requirements, caller ACLs) inside the runtime.
 
-**Policy precedence**: Gateway rules are evaluated first. AGT rules are evaluated second. Both must pass for an action to proceed.
+**Policy precedence:** Gateway rules are evaluated first (at the network boundary). AGT rules are evaluated second (inside the agent process). Both must allow an action for it to proceed. This means a denied action at either layer is blocked, regardless of the other layer's decision.
+
+> [!NOTE]
+> Access Contract-based policy injection is a reference pattern. Today, policy bundles are loaded by the agent application at startup (from file, Key Vault, or URL). Full declarative contract binding is a planned enhancement.
 
 ### Layer 2: AI Control Plane
 
 AGT exports governance telemetry (policy decisions, trust score changes, action interceptions) to Azure Event Hub and Application Insights via the `CitadelAuditExporter`. These events include **correlation IDs** linking AGT decisions to APIM request traces and Foundry execution traces, enabling unified observability dashboards.
 
+The `apim_request_id` correlation field comes from the APIM response header (`x-ms-request-id`), which the agent captures and includes in its governance events.
+
 ### Layer 3: Agent Identity
 
-Entra ID / Agent 365 remains the authoritative source for enterprise agent identity. AGT's Ed25519/SPIFFE identities handle runtime cryptographic credentials. The integration is **federation**: AGT trust scores surface as risk labels in telemetry, not as primary Entra metadata.
+[Entra ID / Agent 365](https://learn.microsoft.com/en-us/entra/id-governance/agent-id-governance-overview) remains the authoritative source for enterprise agent identity. AGT's Ed25519/SPIFFE identities handle runtime cryptographic credentials for agent-to-agent trust. The integration is **attestation-based federation**: AGT trust scores surface as risk labels in telemetry, not as primary Entra metadata. The `EntraIdentityBridge` binds AGT agent identities to Entra object IDs without write-back.
 
 ### Layer 4: Security Fabric
 
-AGT's `data_classification` labels align with Purview sensitivity labels. AGT trust scores can surface as risk signals in Defender for AI through the telemetry pipeline.
+AGT's `data_classification` policy labels align with [Purview sensitivity labels](https://learn.microsoft.com/en-us/purview/sensitivity-labels). AGT trust scores can surface as risk signals in Defender for AI through the Event Hub telemetry pipeline.
 
 ---
 
@@ -60,25 +73,43 @@ Agent Runtime (Spoke)                Citadel Hub                    Azure Monito
 │  ┌────────────────┐  │  request  │  ┌────────────┐  │          │              │
 │  │ AGT Policy     ├──┼──────────►│  │ Rate Limit │──┼────►LLM  │  Event Hub   │
 │  │ Engine         │  │           │  │ Content    │  │          │              │
-│  │                │  │           │  │ JWT Auth   │  │          │  Log         │
-│  │ allow/deny     │  │           │  └────────────┘  │          │  Analytics   │
-│  └──────┬─────────┘  │           └──────────────────┘          └──────┬───────┘
-│         │            │                                                │
-│  ┌──────▼─────────┐  │           ┌──────────────────┐                │
-│  │ Citadel Audit  ├──┼──────────►│  Event Hub /      │────────────────┘
-│  │ Exporter       │  │  events   │  App Insights     │
-│  └────────────────┘  │           └──────────────────┘
-└──────────────────────┘
+│  │                │  │  response │  │ JWT Auth   │  │          │  Log         │
+│  │ allow/deny     │◄─┼──────────┼──│ Cost Attr  │  │          │  Analytics   │
+│  └──────┬─────────┘  │  (incl.  │  └────────────┘  │          └──────┬───────┘
+│         │            │  x-ms-   │                   │                 │
+│         │            │  request- │                   │                 │
+│  ┌──────▼─────────┐  │  id)     ├──────────────────┐│                 │
+│  │ Citadel Audit  ├──┼─────────►│  Event Hub /     │├─────────────────┘
+│  │ Exporter       │  │  events  │  App Insights    ││
+│  │ (correlation)  │  │  with    └──────────────────┘│
+│  └────────────────┘  │  corr ID                     │
+└──────────────────────┘                              │
 ```
+
+**Data flow:**
+1. Agent receives a task and evaluates it against the AGT policy engine (sub-millisecond).
+2. If allowed, the agent sends the LLM request through the Citadel APIM gateway.
+3. APIM applies gateway policies (rate limit, content safety, JWT validation) and returns the response with `x-ms-request-id`.
+4. The agent captures the APIM request ID and includes it as a correlation field in the AGT governance event.
+5. The `CitadelAuditExporter` batches and sends events to Event Hub / App Insights, preserving the hash-chain evidence from AGT's audit system.
 
 ---
 
 ## Getting Started
 
-### 1. Install AGT in your agent environment
+### Prerequisites
+
+- A deployed [Citadel Governance Hub](./quick-deployment-guide.md) (or mock mode for local testing)
+- Python 3.10+
+
+### 1. Install AGT
 
 ```bash
+# Core governance toolkit
 pip install agent-governance-toolkit
+
+# Azure integration (required for production; not needed for mock mode)
+pip install azure-eventhub azure-monitor-opentelemetry-exporter azure-keyvault-secrets azure-identity
 ```
 
 ### 2. Configure the Citadel audit exporter
@@ -86,18 +117,18 @@ pip install agent-governance-toolkit
 Set the following environment variables in your agent spoke:
 
 ```bash
-# Required for audit export
-export CITADEL_EVENTHUB_CONNECTION_STRING="Endpoint=sb://..."
-export CITADEL_APPINSIGHTS_CONNECTION_STRING="InstrumentationKey=..."
+# Required for audit export to Azure
+export CITADEL_EVENTHUB_CONNECTION_STRING="Endpoint=sb://your-namespace.servicebus.windows.net/;..."
+export CITADEL_APPINSIGHTS_CONNECTION_STRING="InstrumentationKey=your-key;IngestionEndpoint=..."
 
-# Optional
-export CITADEL_EVENTHUB_NAME="agt-governance-events"
-export CITADEL_EXPORT_BATCH_SIZE="50"
+# Optional tuning
+export CITADEL_EVENTHUB_NAME="agt-governance-events"    # Default: agt-governance-events
+export CITADEL_EXPORT_BATCH_SIZE="50"                    # Default: 50
 ```
 
 ### 3. Load a policy bundle
 
-AGT policy bundles define agent-level governance rules. They can be loaded from a file, Azure Key Vault, or a URL:
+AGT policy bundles define agent-level governance rules (which actions are allowed, which require justification, which are blocked). They can be loaded from a file, Azure Key Vault, or a URL:
 
 ```python
 from agent_os.integrations.citadel import PolicyBundleResolver
@@ -107,16 +138,34 @@ resolver = PolicyBundleResolver()
 # From a local file (development)
 bundle = resolver.resolve_from_file("policies/agent-policy.yaml")
 
-# From Key Vault (production, referenced by Access Contract)
+# From Key Vault (production)
 bundle = resolver.resolve_from_keyvault(
     vault_url="https://myvault.vault.azure.net",
     secret_name="agt-policy-bundle-customer-support",
 )
 ```
 
+A policy bundle YAML looks like this:
+
+```yaml
+# policies/agent-policy.yaml
+name: customer-support-policy
+version: "1.0"
+rules:
+  - action: "query_customer_database"
+    effect: allow
+    conditions:
+      caller_trust_score_min: 500
+  - action: "delete_*"
+    effect: deny
+  - action: "*"
+    effect: allow
+```
+
 ### 4. Export governance events
 
 ```python
+import asyncio
 from agent_os.exporters import CitadelAuditExporter
 from agent_os.exporters.citadel_exporter import (
     GovernanceEvent,
@@ -135,26 +184,38 @@ event = GovernanceEvent(
     policy_name="customer-support-policy",
     trust_score=800,
     correlation=CorrelationContext(
-        apim_request_id="abc-123",  # From APIM response header
+        apim_request_id="abc-123",  # From APIM response header: x-ms-request-id
         agt_decision_id="def-456",
     ),
 )
 
 exporter.export_event(event)
-await exporter.flush()
+
+# Flush sends buffered events to Event Hub / App Insights
+asyncio.run(exporter.flush())
 ```
 
----
+### 5. End-to-end example
 
-## Access Contract Integration
+For a complete working example with mock mode for local testing, see the [Citadel Governed Agent example](https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/citadel-governed-agent) in the AGT repository.
 
-Citadel Access Contracts can reference an AGT policy bundle so that governance policies are automatically provisioned alongside infrastructure access. See the [sample access contract](https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/citadel-governed-agent/sample-access-contract) in the AGT repository for an example.
+```bash
+# Local mode (no Azure required)
+pip install agent-governance-toolkit
+python examples/citadel-governed-agent/src/agent.py --mock
+
+# With Citadel gateway
+export CITADEL_GATEWAY_URL=https://your-apim.azure-api.net
+export CITADEL_API_KEY=your-subscription-key
+export CITADEL_EVENTHUB_CONNECTION_STRING=Endpoint=sb://...
+python examples/citadel-governed-agent/src/agent.py
+```
 
 ---
 
 ## Coverage Boundaries
 
-Understanding what each system handles avoids duplication:
+Understanding what each system handles avoids duplication and clarifies where to configure each policy:
 
 | Concern | Handled By |
 |---------|-----------|
@@ -167,10 +228,10 @@ Understanding what each system handles avoids duplication:
 | Agent-to-agent trust | AGT Trust Layer (Ed25519, SPIFFE) |
 | Trust scoring (0-1000) | AGT AgentMesh |
 | Tamper-evident audit logs | AGT Audit System |
-| Fleet observability | Citadel Layer 2 + AGT Exporter |
-| Agent enterprise identity | Citadel Layer 3 (Entra) |
+| Correlated fleet observability | Citadel Layer 2 + AGT Exporter |
+| Agent enterprise identity | Citadel Layer 3 (Entra ID) |
 | Threat detection | Citadel Layer 4 (Defender) |
-| Data governance labels | Citadel Layer 4 (Purview) + AGT data_classification |
+| Data governance labels | Citadel Layer 4 (Purview) + AGT `data_classification` |
 
 ---
 
@@ -178,15 +239,30 @@ Understanding what each system handles avoids duplication:
 
 | Component Unavailable | Behavior |
 |----------------------|----------|
-| Azure Event Hub / App Insights | AGT continues operating. Events queue locally and retry. |
-| Citadel APIM Gateway | Agent cannot reach LLM/tools. AGT policy engine still works locally. |
-| AGT Policy Engine | Agent actions proceed ungoverned (configurable fail-open/fail-closed). |
+| Azure Event Hub / App Insights | AGT continues operating normally. Events are buffered in memory and retried on the next flush cycle. Events are lost if the process exits before connectivity is restored. |
+| Citadel APIM Gateway | Agent cannot reach LLM/tools through the gateway. AGT policy engine continues to evaluate actions locally. |
+| AGT Policy Engine | Configurable: fail-open (actions proceed ungoverned) or fail-closed (all actions blocked). Default is fail-closed. |
+| Key Vault (policy bundle source) | Agent cannot load or refresh policy bundles. The last successfully loaded bundle remains active. |
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Access Contract** | A Citadel deployment artifact that declares which AI services, models, tools, and agents a spoke environment can access, along with policy bindings. See [Access Contracts Guide](../bicep/infra/citadel-access-contracts/README.md). |
+| **Policy Bundle** | A YAML file defining AGT governance rules (allow/deny per action, trust score requirements, caller restrictions). |
+| **Trust Score** | A continuous value (0-1000) that AGT assigns to each agent based on behavior, policy compliance, and peer attestations. Scores below configurable thresholds trigger automatic credential revocation. |
+| **SPIFFE** | [Secure Production Identity Framework for Everyone](https://spiffe.io/). AGT uses SPIFFE Verifiable Identity Documents (SVIDs) for runtime agent identity. |
+| **Agent 365** | Microsoft's agent identity platform built on Entra ID. Provides enterprise-grade identity, lifecycle management, and access packages for AI agents. |
+| **`data_classification`** | An AGT policy label that maps to Purview sensitivity labels, enabling data governance enforcement at the agent level. |
 
 ---
 
 ## References
 
-- [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit): Full documentation and source
+- [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit): Full documentation and source code
 - [AGT + Citadel Integration Architecture](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/integrations/citadel-integration.md): Detailed architecture reference
-- [End-to-End Example](https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/citadel-governed-agent): Working example with mock mode
-- [Foundry Citadel Platform](https://aka.ms/foundry-citadel): Full 4-layer architecture
+- [End-to-End Example](https://github.com/microsoft/agent-governance-toolkit/tree/main/examples/citadel-governed-agent): Working example with mock mode for local testing
+- [Foundry Citadel Platform](https://aka.ms/foundry-citadel): Full 4-layer architecture overview
+- [AGT Quickstart](https://github.com/microsoft/agent-governance-toolkit/blob/main/docs/quickstart.md): Zero to governed agents in 10 minutes


### PR DESCRIPTION
## Summary

Adds a comprehensive integration guide for [Agent Governance Toolkit (AGT)](https://github.com/microsoft/agent-governance-toolkit) with Citadel Governance Hub, and a README entry.

### What's included

- **New guide**: `guides/agent-governance-toolkit-integration.md`
  - Why integrate AGT with Citadel (gateway vs. agent-level governance)
  - How AGT maps to Citadel's 4-layer architecture
  - Integration architecture diagram
  - Getting started: audit exporter, policy bundles, governance events
  - Coverage boundaries and failure modes
  - Cross-references to the AGT-side implementation (exporter, policy resolver, example)

- **README update**: Added AGT entry to the Security & Compliance guides table

### Context

This is the Citadel-side counterpart to the AGT-side integration work in [microsoft/agent-governance-toolkit#1778](https://github.com/microsoft/agent-governance-toolkit/pull/1778), which added:
- Citadel audit exporter (Event Hub + App Insights)
- Policy bundle resolver for Access Contracts
- End-to-end governed agent example

AGT complements Citadel by providing agent-level governance (per-action policies, trust scoring, cryptographic identity, tamper-evident audit) that sits inside the agent runtime, while Citadel handles infrastructure perimeter governance at the gateway.

cc @mohamedsaif @sasajuratovic