### PR TITLE
Update PII access contract guidance and service limits

### DIFF
--- a/bicep/infra/citadel-access-contracts/citadel-access-contracts-policy.md
+++ b/bicep/infra/citadel-access-contracts/citadel-access-contracts-policy.md
@@ -500,6 +500,8 @@ When a required role is missing, the policy returns:
 
 AI Citadel Gateway supports PII processing using built-in policy fragments that leverage Azure AI Language Service for detection and anonymization. This allows you to protect sensitive data when sending requests to LLM backends.
 
+>**NOTE:** PII processing has a limit of **5,120** characters for the payload being analyzed by Azure Language service. If the content exceeds this limit, gateway may return a `400 Bad Request` error. To handle this, you can implement a custom policy to split the input content into smaller chunks before passing it to the PII processing fragments.
+
 #### Available PII Policy Fragments
 
 | Fragment | Purpose | Description |

--- a/bicep/infra/citadel-access-contracts/citadel-access-contracts-policy.md
+++ b/bicep/infra/citadel-access-contracts/citadel-access-contracts-policy.md
@@ -500,7 +500,7 @@ When a required role is missing, the policy returns:
 
 AI Citadel Gateway supports PII processing using built-in policy fragments that leverage Azure AI Language Service for detection and anonymization. This allows you to protect sensitive data when sending requests to LLM backends.
 
->**NOTE:** PII processing has a limit of **5,120** characters for the payload being analyzed by Azure Language service. If the content exceeds this limit, gateway may return a `400 Bad Request` error. To handle this, you can implement a custom policy to split the input content into smaller chunks before passing it to the PII processing fragments.
+>**NOTE:** PII processing has a limit of **5,120** characters for the payload being analyzed by Azure Language service (applies only to the inbound request content not the generated content). If the content exceeds this limit, gateway may return a `400 Bad Request` error. To handle this, you can implement a custom policy to split the input content into smaller chunks before passing it to the PII processing fragments.
 
 #### Available PII Policy Fragments
 


### PR DESCRIPTION
This pull request adds important documentation about the payload size limit for PII processing in the AI Citadel Gateway. It clarifies the maximum number of characters supported and offers guidance for handling larger payloads.

Documentation update:

* Added a note specifying that PII processing via Azure Language Service has a 5,120 character limit for inbound request content, and provided guidance on handling content exceeding this limit by splitting it into smaller chunks.