### PR TITLE
fix(rbac): Add resource dependsOn to avoid transient deployment issues

### DIFF
--- a/bicep/infra/apim-gateway-upgrade/services/logic-app.bicep
+++ b/bicep/infra/apim-gateway-upgrade/services/logic-app.bicep
@@ -220,6 +220,9 @@ module azureMonitorConnectionAccess '../../modules/logicapp/api-connection-acces
     location: location
     tags: tags
   }
+  dependsOn: [
+    azureMonitorConnection
+  ]
 }
 
 @description('Name of the Logic App.')

--- a/bicep/infra/modules/functionapp/storageaccount.bicep
+++ b/bicep/infra/modules/functionapp/storageaccount.bicep
@@ -127,6 +127,9 @@ module privateEndpointFile '../networking/private-endpoint.bicep' = {
     dnsSubId: dnsSubscriptionId
     dnsZoneResourceId: storageFileDnsZoneResourceId
   }
+  dependsOn: [
+    privateEndpointBlob
+  ]
 }
 
 module privateEndpointTable '../networking/private-endpoint.bicep' = {
@@ -144,6 +147,9 @@ module privateEndpointTable '../networking/private-endpoint.bicep' = {
     dnsSubId: dnsSubscriptionId
     dnsZoneResourceId: storageTableDnsZoneResourceId
   }
+  dependsOn: [
+    privateEndpointFile
+  ]
 }
 
 module privateEndpointQueue '../networking/private-endpoint.bicep' = {
@@ -161,6 +167,9 @@ module privateEndpointQueue '../networking/private-endpoint.bicep' = {
     dnsSubId: dnsSubscriptionId
     dnsZoneResourceId: storageQueueDnsZoneResourceId
   }
+  dependsOn: [
+    privateEndpointTable
+  ]
 }
 
 

--- a/bicep/infra/modules/functionapp/storageaccount.bicep
+++ b/bicep/infra/modules/functionapp/storageaccount.bicep
@@ -148,6 +148,7 @@ module privateEndpointTable '../networking/private-endpoint.bicep' = {
     dnsZoneResourceId: storageTableDnsZoneResourceId
   }
   dependsOn: [
+    privateEndpointBlob
     privateEndpointFile
   ]
 }
@@ -168,6 +169,8 @@ module privateEndpointQueue '../networking/private-endpoint.bicep' = {
     dnsZoneResourceId: storageQueueDnsZoneResourceId
   }
   dependsOn: [
+    privateEndpointBlob
+    privateEndpointFile
     privateEndpointTable
   ]
 }

--- a/bicep/infra/modules/logicapp/logicapp.bicep
+++ b/bicep/infra/modules/logicapp/logicapp.bicep
@@ -209,4 +209,7 @@ module azureMonitorConnectionAccess 'api-connection-access.bicep' = {
     location: location
     tags: tags
   }
+  dependsOn: [
+    azureMonitorConnection
+  ]
 }


### PR DESCRIPTION
Add explicit / chained dependencies to resolve transient deployment errors seen with these resources. 
For example, "Call to Microsoft.Storage/storageAccounts failed. Error message: An operation is currently performing on this storage account that requires exclusive access."
