### PR TITLE
Add Release Version API and Management Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,42 @@ At a high level, the accelerator includes:
 - [validation](./validation): Jupyter notebooks for post-deployment validation and onboarding.
 - [guides](./guides): operational and architecture documentation.
 
-## 🏗️ Architecture Overview
+## 🏷️ Release Version
+
+The accelerator tracks its release state in a single source-of-truth manifest at the repository
+root — [`release.json`](./release.json). Instead of one monolithic version, it uses **independent,
+component-scoped version tracks** so a change in one subsystem does not force re-versioning of
+unrelated ones:
+
+| Track | Meaning |
+|-------|---------|
+| `master-version` | Umbrella accelerator release version |
+| `routing-version` | LLM request routing logic (backend pools, model resolution, failover) |
+| `backend-contract-version` | Shape of the `llmBackendConfig` backend onboarding contract |
+| `access-contract-version` | Shape of the Citadel Access Contract (products & access policies) |
+| `gateway-upgrade-version` | In-place APIM Gateway Upgrade tooling (currently `-preview`) |
+| `usage-ingestion-version` | Usage ingestion pipeline (Logic App + Function) |
+
+The deployed manifest is exposed at runtime through the **Release Version API** in API Management:
+
+```bash
+curl https://<your-apim-gateway-host>/version
+```
+
+This anonymous `GET /version` endpoint returns `release.json` verbatim (served from an APIM mock
+policy — no backend). It is created automatically by the **primary deployment** and created/updated
+by the **APIM Gateway Upgrade**, so the endpoint always reflects the currently deployed release.
+
+> [!IMPORTANT]
+> The primary deployment (`main.bicep`) is used for the **initial implementation** only. After the
+> hub is live, the **[APIM Gateway Upgrade](./bicep/infra/apim-gateway-upgrade/README.md)** submodule
+> is the standard way to move the accelerator to new releases — applying the new version in place
+> without re-provisioning the APIM service or landing-zone infrastructure.
+
+> 📎 For version-track semantics, SemVer rules, and per-track migration guidance, see the
+> [**Release Version Management Guide**](./guides/release-version-management.md).
+
+## �🏗️ Architecture Overview
 
 AI Citadel Governance Hub follows a **Central-Control-Plane** with decentralized **Agent-Execution-Plane** architecture** that integrates seamlessly with your existing `Azure Enterprise Landing Zone` network topology:
 
@@ -309,7 +344,6 @@ Master AI Citadel Governance Hub implementation and operations with our detailed
 | [**🆕 Governance Hub Benefits**](./guides/governance-hub-benefits.md) | Detailed benefits and stakeholder value of adopting Citadel Governance Hub |
 | [**🆕 Citadel Sizing Guide**](./guides/citadel-sizing-guide.md) | Guidance on sizing the Citadel Governance Hub based on workloads and environments |
 | [**🆕 PTU Estimation Guide**](./guides/put-estimation-guide.md) | Azure OpenAI / Foundry LLM sizing guide for PTU vs Pay-as-you-Go capacity planning |
-
 ### 🏗️ **Landing zone deployment**
 
 | Guide | Description |
@@ -325,6 +359,7 @@ Master AI Citadel Governance Hub implementation and operations with our detailed
 |-------|-------------|
 | [**🆕 LLM Backend Onboarding Guide**](./bicep/infra/llm-backend-onboarding/README.md) | Independent LLM backend routing deployment with load balancing and failover |
 | [**🆕 APIM Gateway Upgrade Guide**](./bicep/infra/apim-gateway-upgrade/README.md) | Update gateway policies, APIs, backends, diagnostics, and named values on an existing APIM instance without re-provisioning infrastructure |
+| [**🆕 Release Version Management**](./guides/release-version-management.md) | Versioning model of the accelerator, the `/version` runtime endpoint, and how to plan and implement migrations |
 
 ### 🔧 **Use-case Onboarding**
 

--- a/bicep/infra/apim-gateway-upgrade/main.bicep
+++ b/bicep/infra/apim-gateway-upgrade/main.bicep
@@ -61,6 +61,9 @@ param updateLLMPolicyFragments bool = true
 @description('Update the Unified AI Wildcard API definition, product, and policy')
 param updateUnifiedAiApi bool = true
 
+@description('Create or update the Release Version API (single GET operation returning release.json)')
+param updateReleaseVersionApi bool = true
+
 @description('Update JWT authentication named values (JWT-TenantId, JWT-AppRegistrationId, JWT-Issuer, JWT-OpenIdConfigUrl)')
 param updateJwtNamedValues bool = true
 
@@ -544,6 +547,19 @@ module apiUnifiedAI '../modules/apim/unified-ai-api.bicep' = if (updateUnifiedAi
     llmPolicyFragments
     azMonitorLoggerNew
   ]
+}
+
+// =====================================================================
+//    APIs — Release Version API
+// =====================================================================
+
+// Lightweight API exposing a single GET operation that returns the accelerator
+// release manifest (release.json) as static JSON content via a mock response.
+module apiReleaseVersion '../modules/apim/version-api.bicep' = if (updateReleaseVersionApi) {
+  name: 'release-version-api-upgrade'
+  params: {
+    apiManagementName: apimService.name
+  }
 }
 
 // =====================================================================

--- a/bicep/infra/modules/apim/apim.bicep
+++ b/bicep/infra/modules/apim/apim.bicep
@@ -479,6 +479,16 @@ module apiUnifiedAI './unified-ai-api.bicep' = if (enableUnifiedAiApi) {
   ]
 }
 
+////// Release Version API /////////////
+// Lightweight API exposing a single GET operation that returns the accelerator
+// release manifest (release.json) as static JSON content via a mock response.
+module apiReleaseVersion './version-api.bicep' = {
+  name: 'release-version-api'
+  params: {
+    apiManagementName: apimService.name
+  }
+}
+
 ////// JWT Authentication Named Values /////////////
 // These named values support JWT authentication across all APIs (Azure OpenAI,
 // Universal LLM, and Unified AI). The security-handler fragment is included in all

--- a/bicep/infra/modules/apim/version-api.bicep
+++ b/bicep/infra/modules/apim/version-api.bicep
@@ -1,0 +1,147 @@
+/**
+ * @module version-api
+ * @description Creates a lightweight "Release Version" API in API Management that exposes
+ * a single GET operation returning the accelerator release version manifest (release.json)
+ * as static JSON content. The content is embedded into an operation-level policy at deploy
+ * time via a mock (return-response) response, so no backend is required.
+ *
+ * This module is shared by both the primary accelerator deployment (apim.bicep) and the
+ * APIM Gateway Upgrade (apim-gateway-upgrade/main.bicep) so the version endpoint is always
+ * created/updated to reflect the currently deployed release manifest.
+ */
+
+// ------------------
+//    PARAMETERS
+// ------------------
+
+@description('The name of the API Management instance to deploy the version API to.')
+@minLength(1)
+param apiManagementName string
+
+@description('The name (resource id segment) of the version API.')
+param versionApiName string = 'release-version-api'
+
+@description('The display name of the version API.')
+param versionApiDisplayName string = 'Release Version API'
+
+@description('The description of the version API.')
+param versionApiDescription string = 'Returns the AI Hub Gateway accelerator release version manifest (release.json) as static JSON content.'
+
+@description('The relative path (URL suffix) for the version API in the APIM gateway.')
+param versionApiPath string = 'version'
+
+@description('Set to true if a subscription key is required to call the version API. Defaults to false so the endpoint can be queried anonymously (health/version style).')
+param subscriptionRequired bool = false
+
+@description('The name of the subscription key header (only relevant when subscriptionRequired is true).')
+param subscriptionKeyName string = 'api-key'
+
+@description('The raw JSON content of the release manifest to serve. Defaults to the repository release.json.')
+param releaseContent string = loadTextContent('../../../../release.json')
+
+// ------------------
+//    VARIABLES
+// ------------------
+
+// The release manifest is embedded verbatim into a return-response policy as a literal body.
+// release.json contains only JSON-safe characters ({ } " : , and version strings) so it does
+// not need XML escaping. If this ever changes, escape < > & before embedding.
+// NOTE: Bicep multi-line strings ('''...''') do NOT support interpolation, so the policy is
+// composed from a prefix and suffix with the release content concatenated in between.
+var versionApiPolicyPrefix = '''
+<policies>
+    <inbound>
+        <base />
+        <return-response>
+            <set-status code="200" reason="OK" />
+            <set-header name="Content-Type" exists-action="override">
+                <value>application/json</value>
+            </set-header>
+            <set-body>'''
+
+var versionApiPolicySuffix = '''</set-body>
+        </return-response>
+    </inbound>
+    <backend>
+        <base />
+    </backend>
+    <outbound>
+        <base />
+    </outbound>
+    <on-error>
+        <base />
+    </on-error>
+</policies>'''
+
+var versionApiPolicyXml = '${versionApiPolicyPrefix}${releaseContent}${versionApiPolicySuffix}'
+
+// ------------------
+//    RESOURCES
+// ------------------
+
+resource apimService 'Microsoft.ApiManagement/service@2024-06-01-preview' existing = {
+  name: apiManagementName
+}
+
+resource versionApi 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
+  name: versionApiName
+  parent: apimService
+  properties: {
+    apiType: 'http'
+    description: versionApiDescription
+    displayName: versionApiDisplayName
+    path: versionApiPath
+    protocols: [
+      'https'
+    ]
+    subscriptionRequired: subscriptionRequired
+    subscriptionKeyParameterNames: {
+      header: subscriptionKeyName
+    }
+    serviceUrl: 'https://to-be-replaced-by-policy'
+  }
+}
+
+resource versionApiGetOperation 'Microsoft.ApiManagement/service/apis/operations@2024-06-01-preview' = {
+  name: 'get-version'
+  parent: versionApi
+  properties: {
+    displayName: 'Get Release Version'
+    method: 'GET'
+    urlTemplate: '/'
+    description: 'Returns the accelerator release version manifest as static JSON content.'
+    responses: [
+      {
+        statusCode: 200
+        description: 'The release version manifest.'
+        representations: [
+          {
+            contentType: 'application/json'
+          }
+        ]
+      }
+    ]
+  }
+}
+
+resource versionApiGetOperationPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2024-06-01-preview' = {
+  name: 'policy'
+  parent: versionApiGetOperation
+  properties: {
+    format: 'rawxml'
+    value: versionApiPolicyXml
+  }
+}
+
+// ------------------
+//    OUTPUTS
+// ------------------
+
+@description('The resource id of the version API.')
+output versionApiId string = versionApi.id
+
+@description('The name (resource id segment) of the version API.')
+output versionApiResourceName string = versionApi.name
+
+@description('The gateway path of the version API.')
+output versionApiPathOut string = versionApiPath

--- a/guides/release-version-management.md
+++ b/guides/release-version-management.md
@@ -1,0 +1,200 @@
+# 🏷️ Release Version Management Guide
+
+This guide explains the versioning model of the Citadel Governance Hub accelerator, what each
+version track in [`release.json`](../release.json) means, how versions are surfaced at runtime, and
+how to plan and implement migrations when a version changes.
+
+> [!IMPORTANT]
+> **The primary accelerator deployment (`bicep/infra/main.bicep`) is for the _initial_
+> implementation only.** Once the hub is established, the **[APIM Gateway Upgrade](../bicep/infra/apim-gateway-upgrade/README.md)**
+> submodule is the standard, supported way to adopt new accelerator releases — it applies the new
+> version in place (policies, APIs, backends, fragments, named values, and the `/version` manifest)
+> **without re-provisioning** the APIM service or the surrounding landing-zone infrastructure.
+> Re-running the full `main.bicep` for version upgrades is not the intended path and risks
+> unnecessary churn on already-provisioned resources.
+
+---
+
+## Overview
+
+The accelerator ships a single source-of-truth version manifest at the repository root:
+[`release.json`](../release.json). Rather than a single monolithic version, the accelerator uses
+**independent, component-scoped version tracks** so that a change in one subsystem (for example the
+routing policy logic) does not force a full re-versioning of unrelated subsystems (for example usage
+ingestion).
+
+```jsonc
+{
+    "master-version": "1.0.0",
+    "routing-version": "1.0.0",
+    "backend-contract-version": "1.0.0",
+    "access-contract-version": "1.0.0",
+    "gateway-upgrade-version": "1.0.0-preview",
+    "usage-ingestion-version": "1.0.0"
+}
+```
+
+All version tracks follow [Semantic Versioning](https://semver.org/) (`MAJOR.MINOR.PATCH`), with an
+optional pre-release suffix (for example `-preview`):
+
+- **MAJOR** — breaking change. Requires a planned migration (contract change, path change, or
+  behavioral change that existing consumers/configurations depend on).
+- **MINOR** — backward-compatible feature addition. Safe to adopt without consumer changes.
+- **PATCH** — backward-compatible fix. Safe to adopt without consumer changes.
+- **`-preview`** — the track is functional but the surface may still change before it is declared
+  stable. Pin to an exact version in production and validate before upgrading.
+
+---
+
+## Version Tracks
+
+| Track | Scope | What changes it | Owned by |
+|-------|-------|-----------------|----------|
+| **`master-version`** | The overall accelerator release. Acts as the umbrella "product" version that consumers cite when reporting the deployed release. Bumped whenever any component track has a notable change. | Any coordinated release. | Whole repo |
+| **`routing-version`** | The LLM request routing logic — backend pool selection, model-to-backend resolution, load balancing, failover, alias fallback, and the dynamic routing policy fragments. | Changes to `llm-policy-fragments.*`, `llm-backend-pools.bicep`, routing/target policies. | `bicep/infra/modules/apim` |
+| **`backend-contract-version`** | The shape of the **backend configuration contract** (`llmBackendConfig`) consumed during onboarding — backend types, auth types, model object properties, circuit breaker defaults. | Changes to the `llmBackendConfig` schema or `llm-backend-onboarding` parameter surface. | `bicep/infra/llm-backend-onboarding` |
+| **`access-contract-version`** | The shape of the **Citadel Access Contract** — product policies, JWT/subscription access patterns, per-use-case product definitions, and the access-contract parameter surface. | Changes to `citadel-access-contracts` schema, product policy templates, or access-pattern behavior. | `bicep/infra/citadel-access-contracts` |
+| **`gateway-upgrade-version`** | The in-place **APIM Gateway Upgrade** tooling used to update an existing gateway without re-provisioning. Currently `-preview`. | Changes to `bicep/infra/apim-gateway-upgrade`. | `bicep/infra/apim-gateway-upgrade` |
+| **`usage-ingestion-version`** | The **usage ingestion pipeline** — Logic App workflows and the usage-ingestion Function that process usage/log streams into the reporting store. | Changes to `src/usage-ingestion-logicapp`, the usage-ingestion function, or the ingestion data contract. | `src/usage-ingestion-*` |
+
+> [!TIP]
+> The tracks are intentionally decoupled. When evaluating an upgrade, compare **each** track against
+> what you currently run — a `usage-ingestion-version` bump has no bearing on your routing config,
+> and vice versa.
+
+---
+
+## Runtime Version Endpoint
+
+The deployed version manifest is exposed at runtime through the **Release Version API** in API
+Management, so operators and consumers can confirm exactly which release a gateway is running
+**without** inspecting the deployment source.
+
+- **API:** `Release Version API` (`release-version-api`)
+- **Path:** `GET /version`
+- **Auth:** anonymous by default (no subscription key required) — a health/version-style endpoint
+- **Response:** the verbatim contents of `release.json` as `application/json`
+
+```bash
+curl https://<your-apim-gateway-host>/version
+```
+
+The endpoint is served entirely from an APIM **mock (`return-response`)** policy — the release
+manifest is embedded into the operation policy at deploy time, so there is no backend dependency and
+no latency cost.
+
+### How it gets created / updated
+
+| Deployment | Behavior |
+|------------|----------|
+| **Primary accelerator** (`bicep/infra/main.bicep` → `apim.bicep`) | Creates the Release Version API automatically with the content of `release.json` at deploy time. |
+| **APIM Gateway Upgrade** (`bicep/infra/apim-gateway-upgrade/main.bicep`) | Creates **or** updates the Release Version API (toggle `updateReleaseVersionApi`, default `true`) so the endpoint always reflects the currently deployed manifest. |
+
+Both paths use the same shared module — `bicep/infra/modules/apim/version-api.bicep` — which reads
+`release.json` via `loadTextContent` relative to the module. Bump the manifest, redeploy (or run the
+gateway upgrade), and the `/version` endpoint reflects the new values.
+
+---
+
+## Bumping a Version
+
+1. **Identify the affected track(s).** Only bump tracks whose component actually changed.
+2. **Choose the SemVer increment** (MAJOR / MINOR / PATCH) based on the impact rules above.
+3. **Bump `master-version`** whenever any track changes in a release that consumers should cite.
+4. **Update [`release.json`](../release.json)** with the new values.
+5. **Publish the new release.** For an **existing** hub, run the **[APIM Gateway Upgrade](../bicep/infra/apim-gateway-upgrade/README.md)**
+   with the relevant feature toggles enabled — this is the standard upgrade path and updates the
+   `/version` manifest in place. Only the very **first** implementation uses the primary
+   `main.bicep` deployment.
+6. **Validate** with `curl https://<gateway-host>/version`.
+
+---
+
+## Migration Strategy
+
+### The upgrade model: initial deployment vs. release upgrades
+
+The accelerator has two distinct lifecycle phases:
+
+| Phase | Tooling | When |
+|-------|---------|------|
+| **Initial implementation** | Primary deployment — `bicep/infra/main.bicep` (`azd provision`) | Once, to stand up the hub and its landing-zone infrastructure. |
+| **Release upgrades** | **[APIM Gateway Upgrade](../bicep/infra/apim-gateway-upgrade/README.md)** — `bicep/infra/apim-gateway-upgrade/main.bicep` | Every subsequent move to a new accelerator release. |
+
+After the hub is live, **all version upgrades flow through the APIM Gateway Upgrade submodule.** It
+targets an existing APIM instance and applies the new release's policies, APIs, backends, policy
+fragments, named values, diagnostics, and the `/version` manifest **without re-provisioning** the
+APIM service or surrounding infrastructure. Its feature toggles (e.g. `updateLLMPolicyFragments`,
+`updateLLMBackends`, `updateUnifiedAiApi`, `updateReleaseVersionApi`) let you scope the upgrade to
+exactly the tracks that changed.
+
+How you migrate then depends on **which track** changed and **whether the increment is MAJOR**.
+
+### Non-breaking (MINOR / PATCH) on any track
+
+Adopt directly by running the **APIM Gateway Upgrade** with the relevant feature toggles enabled. No
+consumer changes are required.
+
+### `routing-version` (MAJOR)
+
+Routing changes affect how requests reach backends (pool composition, model resolution, failover).
+
+- Roll out to a **non-production** gateway first and run the routing/backends validation notebooks.
+- Prefer the **APIM Gateway Upgrade** to update policy fragments and backend pools in place
+  (`updateLLMPolicyFragments`, `updateLLMBackendPools`, `updateLLMBackends`).
+- Verify load balancing, failover, and alias fallback behavior before promoting to production.
+
+### `backend-contract-version` (MAJOR)
+
+The `llmBackendConfig` schema changed (for example a renamed/removed property or a new required
+field).
+
+- Update your backend parameter file(s) to the new contract **before** deploying — a stale config
+  against a new contract can fail validation or route incorrectly.
+- Consult [LLM Backend Onboarding](../bicep/infra/llm-backend-onboarding/README.md) for the current
+  schema, then re-run onboarding.
+
+### `access-contract-version` (MAJOR)
+
+The Citadel Access Contract product/policy surface changed.
+
+- Review each Access Contract parameter file against the new schema.
+- Re-deploy the access contracts; validate JWT and subscription access patterns per use case with
+  the access-contract validation notebooks.
+- See [AI Citadel Access Contracts](../bicep/infra/citadel-access-contracts/README.md).
+
+### `gateway-upgrade-version` (`-preview`)
+
+The in-place upgrade tooling is evolving.
+
+- Pin to the exact version you validated. Read the
+  [APIM Gateway Upgrade Guide](../bicep/infra/apim-gateway-upgrade/README.md) release notes before
+  adopting a newer upgrade tool.
+- For the first run against an existing/legacy gateway, enable as many feature toggles as possible
+  in a **non-production** environment to detect drift early (see the upgrade guide).
+
+### `usage-ingestion-version` (MAJOR)
+
+The ingestion workflows or data contract changed (for example a new field in the usage record or a
+changed store schema).
+
+- Update the Logic App / Function first, then confirm downstream reporting (Cosmos/Power BI) still
+  reads correctly.
+- Because ingestion is decoupled from the gateway data plane, this migration can typically be
+  performed independently and without gateway downtime.
+
+### General guidance
+
+- **Migrate one MAJOR track at a time** where possible, to isolate risk and simplify rollback.
+- **Always validate in non-production first**, then promote.
+- **Record the deployed `master-version`** (e.g. from the `/version` endpoint) in your change log so
+  you can correlate incidents with the exact release.
+
+---
+
+## Related Guides
+
+- [APIM Gateway Upgrade Guide](../bicep/infra/apim-gateway-upgrade/README.md)
+- [LLM Backend Onboarding](../bicep/infra/llm-backend-onboarding/README.md)
+- [AI Citadel Access Contracts](../bicep/infra/citadel-access-contracts/README.md)
+- [Resiliency Guide](./resiliency-guide.md)

--- a/release.json
+++ b/release.json
@@ -1,0 +1,8 @@
+{
+    "master-version": "1.0.0",
+    "routing-version": "1.0.0",
+    "backend-contract-version": "1.0.0",
+    "access-contract-version": "1.0.0",
+    "gateway-upgrade-version": "1.0.0-preview",
+    "usage-ingestion-version": "1.0.0"
+}


### PR DESCRIPTION
This pull request introduces a comprehensive release versioning system for the accelerator, including a new single-source-of-truth manifest (`release.json`), a runtime `/version` API endpoint, and extensive documentation and Bicep module changes to support version management and upgrade workflows. The changes ensure that each subsystem can be versioned independently and that the current release state is always visible through the API Management gateway.

**Release Versioning and Management:**

- Added `release.json` at the repository root as the authoritative manifest, tracking independent version numbers for all major accelerator subsystems.
- Created the [Release Version Management Guide](guides/release-version-management.md) detailing the versioning model, track semantics, migration strategies, and upgrade workflows.
- Updated `README.md` to introduce the versioning system, `/version` endpoint, and reference the new management guide [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R103) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L312) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R362).

**API Management Integration:**

- Added a new Bicep module (`bicep/infra/modules/apim/version-api.bicep`) that deploys a lightweight, anonymous `GET /version` API in APIM, serving the manifest as static JSON via a mock policy.
- Integrated the version API module into both the primary deployment (`apim.bicep`) and the APIM Gateway Upgrade workflow (`apim-gateway-upgrade/main.bicep`), with a new `updateReleaseVersionApi` toggle parameter [[1]](diffhunk://#diff-e4150ae8b5158746366024e8568d1c4e7418db207d470282fc46e42d787d16a5R482-R491) [[2]](diffhunk://#diff-da4a224a636db71ea763eebf1a49eaabe174b4d86effd306af8843cdcf20ca63R64-R66) [[3]](diffhunk://#diff-da4a224a636db71ea763eebf1a49eaabe174b4d86effd306af8843cdcf20ca63R552-R564).

These changes provide a robust, transparent, and decoupled release management process for the accelerator, improving upgrade safety and operational clarity.

**References:** [[1]](diffhunk://#diff-16903c7a4898d982fab69d1f9b86f84345e498ec58965bf6047383688818b4c3R1-R8) [[2]](diffhunk://#diff-ed769341ffb5756e80724381d8cf851f218db570a86d34488ebbd861d966b4c1R1-R200) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68-R103) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L312) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R362) [[6]](diffhunk://#diff-1d5c8b78a115009b8d62357376ec02a63e655ab9648f07cdd411b2c0b4ab76b7R1-R147) [[7]](diffhunk://#diff-e4150ae8b5158746366024e8568d1c4e7418db207d470282fc46e42d787d16a5R482-R491) [[8]](diffhunk://#diff-da4a224a636db71ea763eebf1a49eaabe174b4d86effd306af8843cdcf20ca63R64-R66) [[9]](diffhunk://#diff-da4a224a636db71ea763eebf1a49eaabe174b4d86effd306af8843cdcf20ca63R552-R564)