### PR TITLE
updated guide links

### DIFF
--- a/guides/full-deployment-guide.md
+++ b/guides/full-deployment-guide.md
@@ -1009,7 +1009,7 @@ Visit the [Deployment Troubleshooting Guide](./#) for common issues and resoluti
   - [Citadel Access Contracts](./citadel-access-contracts.md)
 
 - **Deploy LLM Backends**
-   - [Onboard Existing LLMs](./LLM-Backend-Onboarding-Guide.md)
+   - [Onboard Existing LLMs](../bicep/infra/llm-backend-onboarding/README.md)
    - [LLM Access Guide](./llm-access-guide.md)
 
 ---


### PR DESCRIPTION
This pull request updates the onboarding documentation link for LLM backends in the deployment guide to point to the correct location. This ensures users are directed to the accurate and current onboarding instructions.

* Documentation update:
  * Updated the "Onboard Existing LLMs" link in `guides/full-deployment-guide.md` to reference `../bicep/infra/llm-backend-onboarding/README.md` instead of the previous location.