### PR TITLE
Refactor URL rewriting logic for backend authorization and onboarding

### DIFF
--- a/bicep/infra/llm-backend-onboarding/modules/policies/frag-set-backend-authorization.xml
+++ b/bicep/infra/llm-backend-onboarding/modules/policies/frag-set-backend-authorization.xml
@@ -238,13 +238,15 @@
         <when condition="@(context.Variables.GetValueOrDefault<string>("targetPoolType", "") == "azure-openai")">
             <set-variable name="rewriteTemplate" value="@{
                 string requestedModel = (string)context.Variables["requestedModel"];
-                // APIM's context.Request.Url.Path returns the ORIGINAL request path,
-                // which includes the API path prefix (e.g. 'models/...' for Universal LLM API,
-                // 'openai/...' for Azure OpenAI API). Strip the API prefix before prepending
-                // the backend prefix so the rewritten URL doesn't double up the segment
-                // (e.g. 'openai/openai/deployments/.../chat/completions' or 'models/models/...').
+                // Derive from context.Request.OriginalUrl.Path (the IMMUTABLE original request
+                // path) rather than context.Request.Url.Path, because APIM's Url.Path DOES reflect
+                // prior <rewrite-uri> calls. When this fragment re-runs during an alias-fallback
+                // retry hop, reading the already-rewritten Url.Path and re-prepending the backend
+                // prefix stacks the segment (e.g. 'openai/openai/deployments/...' or
+                // 'models/models/chat/completions') -> backend 404. OriginalUrl.Path + API-prefix
+                // strip keeps the rewrite idempotent across re-runs.
                 string apiPath = (context.Api.Path ?? "").Trim('/');
-                string path = context.Request.Url.Path.TrimStart('/');
+                string path = context.Request.OriginalUrl.Path.TrimStart('/');
                 if (!string.IsNullOrEmpty(apiPath))
                 {
                     if (path.StartsWith(apiPath + "/", StringComparison.OrdinalIgnoreCase))
@@ -262,12 +264,14 @@
         </when>
         <when condition="@(context.Variables.GetValueOrDefault<string>("targetPoolType", "") == "ai-foundry")">
             <set-variable name="rewriteTemplate" value="@{
-                // APIM's context.Request.Url.Path returns the ORIGINAL request path,
-                // which includes the API path prefix (e.g. 'models/...' for Universal LLM API).
-                // Strip the API prefix before prepending the backend prefix so the rewritten URL
-                // doesn't double up the segment (e.g. 'models/models/chat/completions').
+                // Derive from context.Request.OriginalUrl.Path (the IMMUTABLE original request
+                // path) rather than context.Request.Url.Path, because APIM's Url.Path DOES reflect
+                // prior <rewrite-uri> calls. When this fragment re-runs during an alias-fallback
+                // retry hop, reading the already-rewritten Url.Path and re-prepending 'models/'
+                // stacks the segment (e.g. 'models/models/chat/completions') -> backend 404.
+                // OriginalUrl.Path + API-prefix strip keeps the rewrite idempotent across re-runs.
                 string apiPath = (context.Api.Path ?? "").Trim('/');
-                string path = context.Request.Url.Path.TrimStart('/');
+                string path = context.Request.OriginalUrl.Path.TrimStart('/');
                 if (!string.IsNullOrEmpty(apiPath))
                 {
                     if (path.StartsWith(apiPath + "/", StringComparison.OrdinalIgnoreCase))

--- a/bicep/infra/modules/apim/policies/frag-set-backend-authorization.xml
+++ b/bicep/infra/modules/apim/policies/frag-set-backend-authorization.xml
@@ -238,13 +238,15 @@
         <when condition="@(context.Variables.GetValueOrDefault<string>("targetPoolType", "") == "azure-openai")">
             <set-variable name="rewriteTemplate" value="@{
                 string requestedModel = (string)context.Variables["requestedModel"];
-                // APIM's context.Request.Url.Path returns the ORIGINAL request path,
-                // which includes the API path prefix (e.g. 'models/...' for Universal LLM API,
-                // 'openai/...' for Azure OpenAI API). Strip the API prefix before prepending
-                // the backend prefix so the rewritten URL doesn't double up the segment
-                // (e.g. 'openai/openai/deployments/.../chat/completions' or 'models/models/...').
+                // Derive from context.Request.OriginalUrl.Path (the IMMUTABLE original request
+                // path) rather than context.Request.Url.Path, because APIM's Url.Path DOES reflect
+                // prior <rewrite-uri> calls. When this fragment re-runs during an alias-fallback
+                // retry hop, reading the already-rewritten Url.Path and re-prepending the backend
+                // prefix stacks the segment (e.g. 'openai/openai/deployments/...' or
+                // 'models/models/chat/completions') -> backend 404. OriginalUrl.Path + API-prefix
+                // strip keeps the rewrite idempotent across re-runs.
                 string apiPath = (context.Api.Path ?? "").Trim('/');
-                string path = context.Request.Url.Path.TrimStart('/');
+                string path = context.Request.OriginalUrl.Path.TrimStart('/');
                 if (!string.IsNullOrEmpty(apiPath))
                 {
                     if (path.StartsWith(apiPath + "/", StringComparison.OrdinalIgnoreCase))
@@ -262,12 +264,14 @@
         </when>
         <when condition="@(context.Variables.GetValueOrDefault<string>("targetPoolType", "") == "ai-foundry")">
             <set-variable name="rewriteTemplate" value="@{
-                // APIM's context.Request.Url.Path returns the ORIGINAL request path,
-                // which includes the API path prefix (e.g. 'models/...' for Universal LLM API).
-                // Strip the API prefix before prepending the backend prefix so the rewritten URL
-                // doesn't double up the segment (e.g. 'models/models/chat/completions').
+                // Derive from context.Request.OriginalUrl.Path (the IMMUTABLE original request
+                // path) rather than context.Request.Url.Path, because APIM's Url.Path DOES reflect
+                // prior <rewrite-uri> calls. When this fragment re-runs during an alias-fallback
+                // retry hop, reading the already-rewritten Url.Path and re-prepending 'models/'
+                // stacks the segment (e.g. 'models/models/chat/completions') -> backend 404.
+                // OriginalUrl.Path + API-prefix strip keeps the rewrite idempotent across re-runs.
                 string apiPath = (context.Api.Path ?? "").Trim('/');
-                string path = context.Request.Url.Path.TrimStart('/');
+                string path = context.Request.OriginalUrl.Path.TrimStart('/');
                 if (!string.IsNullOrEmpty(apiPath))
                 {
                     if (path.StartsWith(apiPath + "/", StringComparison.OrdinalIgnoreCase))

--- a/bicep/infra/modules/apim/policies/unified-ai-api-policy.xml
+++ b/bicep/infra/modules/apim/policies/unified-ai-api-policy.xml
@@ -166,6 +166,16 @@
             <choose>
                 <when condition="@{
                     if (!context.Variables.GetValueOrDefault<bool>("is-alias", false)) { return false; }
+                    // Only advance to a fallback member AFTER a real failure on the previous hop.
+                    // The <retry> body executes once as the INITIAL attempt (with the primary member
+                    // selected during inbound). On that first execution there is no backend response
+                    // yet (StatusCode == 0), so we must NOT switch — otherwise the primary member is
+                    // skipped and the backend fragments re-run before the primary was ever forwarded.
+                    // On subsequent executions (triggered by the 429/5xx retry condition) the failed
+                    // status is present, so we advance to the next fallback member.
+                    var sc = context.Response?.StatusCode ?? 0;
+                    var previousHopFailed = sc == 429 || sc >= 500;
+                    if (!previousHopFailed) { return false; }
                     var fallback = context.Variables.GetValueOrDefault<JArray>("alias-fallback-members");
                     var idx = context.Variables.GetValueOrDefault<int>("alias-retry-index", 0);
                     return fallback != null && idx < fallback.Count;

--- a/bicep/infra/modules/apim/policies/universal-llm-api-policy-v2.xml
+++ b/bicep/infra/modules/apim/policies/universal-llm-api-policy-v2.xml
@@ -105,6 +105,17 @@
             <choose>
                 <when condition="@{
                     if (!context.Variables.GetValueOrDefault<bool>("is-alias", false)) { return false; }
+                    // Only advance to a fallback member AFTER a real failure on the previous hop.
+                    // The <retry> body executes once as the INITIAL attempt (with the primary member
+                    // selected during inbound). On that first execution there is no backend response
+                    // yet (StatusCode == 0), so we must NOT switch — otherwise the primary member is
+                    // skipped and set-backend-authorization re-runs against the already-rewritten URL
+                    // (which, with the OriginalUrl.Path fix, stays correct — but skipping the primary
+                    // member would still route to the wrong model). On subsequent executions (triggered
+                    // by the 429/5xx retry condition) the failed status is present, so we advance.
+                    var sc = context.Response?.StatusCode ?? 0;
+                    var previousHopFailed = sc == 429 || sc >= 500;
+                    if (!previousHopFailed) { return false; }
                     var fallback = context.Variables.GetValueOrDefault<JArray>("alias-fallback-members");
                     var idx = context.Variables.GetValueOrDefault<int>("alias-retry-index", 0);
                     return fallback != null && idx < fallback.Count;

--- a/validation/llm-backend-onboarding-runner.ipynb
+++ b/validation/llm-backend-onboarding-runner.ipynb
@@ -219,8 +219,6 @@
     "    { \"name\": \"adv-gpt\",        \"models\": [\"gpt-5.2\", \"gpt-5.4-mini\", \"gpt-4.1\"], \"strategy\": \"priority\" },\n",
     "    # Cost/latency-optimized GPT — prefers the smaller model with full-size fallback.\n",
     "    { \"name\": \"fast-gpt\",       \"models\": [\"gpt-5.4-mini\", \"gpt-4.1\"],            \"strategy\": \"priority\" },\n",
-    "    # Reasoning workloads — DeepSeek as primary, GPT-5.2 as fallback.\n",
-    "    { \"name\": \"reasoning\",      \"models\": [\"DeepSeek-R1\", \"gpt-5.2\"],             \"strategy\": \"priority\" },\n",
     "    # Stable embeddings alias — easy to swap underlying model later without\n",
     "    # touching client code.\n",
     "    { \"name\": \"embeddings\",     \"models\": [\"text-embedding-3-large\"],             \"strategy\": \"priority\" },\n",


### PR DESCRIPTION
This pull request addresses two main areas: improvements to API Management (APIM) policy logic for backend URL rewriting and alias fallback handling, and a minor update to the validation notebook. The changes enhance the reliability and correctness of backend routing, especially during retries and fallback scenarios.

**APIM Policy Improvements**

* Ensured that URL rewriting uses `context.Request.OriginalUrl.Path` instead of `context.Request.Url.Path` to prevent stacking path segments during retries or fallback hops, making the rewrite operation idempotent and avoiding backend 404 errors. This change is applied to both the `azure-openai` and `ai-foundry` backend types in the following policy fragments: `bicep/infra/llm-backend-onboarding/modules/policies/frag-set-backend-authorization.xml` and `bicep/infra/modules/apim/policies/frag-set-backend-authorization.xml`. [[1]](diffhunk://#diff-4b2abbe7a4f57023a714f51ba8e3db52442c0b544a30610d0583972a630a59caL241-R249) [[2]](diffhunk://#diff-4b2abbe7a4f57023a714f51ba8e3db52442c0b544a30610d0583972a630a59caL265-R274)

* Updated the fallback logic in the alias retry mechanism to only advance to the next fallback backend member after an actual failure (HTTP 429 or 5xx), preventing premature fallback and ensuring the primary backend is always attempted first. This logic is implemented in both `unified-ai-api-policy.xml` and `universal-llm-api-policy-v2.xml`. [[1]](diffhunk://#diff-deaa9849a8d0de8f9a8b62f40fbf4c670c0f5b6c9159720e5ded0b2fbd687de5R169-R178) [[2]](diffhunk://#diff-39bef4053a50ba0aea22ae957cb9c2be0f742aedab6a127def6ef81df0a3730eR108-R118)

**Validation Notebook Update**

* Removed the "reasoning" model alias from the test configuration in `validation/llm-backend-onboarding-runner.ipynb`, possibly reflecting a change in supported or recommended model routing.