### PR TITLE
Add cost estimator and high availability for Azure Managed Redis

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -10,3 +10,19 @@ services:
     project: ./src/usage-ingestion-logicapp
     language: js
     host: function
+# hooks:
+#   # Azure Managed Redis (Microsoft.Cache/redisEnterprise) can hit a transient create failure that
+#   # leaves the cluster in a terminal "Failed" state. A rerun then fails with "A resource with this
+#   # name already exists or is in a conflicting state." This hook deletes only a failed Redis before
+#   # provisioning so `azd up` self-heals; it is a no-op when Redis is absent or healthy.
+#   preprovision:
+#     windows:
+#       shell: pwsh
+#       run: ./scripts/remove-failed-managed-redis.ps1
+#       continueOnError: false
+#       interactive: false
+#     posix:
+#       shell: sh
+#       run: ./scripts/remove-failed-managed-redis.sh
+#       continueOnError: false
+#       interactive: false

--- a/bicep/infra/main.bicep
+++ b/bicep/infra/main.bicep
@@ -391,6 +391,10 @@ param redisSkuCapacity int = 2
 @description('Minimum TLS version for Redis connections.')
 param redisMinimumTlsVersion string = '1.2'
 
+@description('High availability / zone redundancy for Azure Managed Redis. Enabled (default) replicates data across availability zones. Set to Disabled if cluster creation intermittently fails with "CreateFailed" due to zonal capacity constraints in the selected region (reduces the availability SLA).')
+@allowed([ 'Enabled', 'Disabled' ])
+param redisHighAvailability string = 'Enabled'
+
 //
 // ACCELERATOR SPECIFIC PARAMETERS - Additional parameters for the solution (should not be modified without careful consideration)
 //
@@ -936,6 +940,7 @@ module managedRedis './modules/redis/redis.bicep' = if (enableManagedRedis) {
     skuCapacity: redisSkuCapacity
     publicNetworkAccess: redisPublicNetworkAccess
     minimumTlsVersion: redisMinimumTlsVersion
+    highAvailability: redisHighAvailability
     usePrivateEndpoint: true
     redisPrivateEndpointName: !empty(redisPrivateEndpointName) ? redisPrivateEndpointName : '${abbrs.cacheRedis}pe-${resourceToken}'
     vNetName: useExistingVnet ? vnetExisting.outputs.vnetName : vnet.outputs.vnetName

--- a/bicep/infra/main.bicepparam
+++ b/bicep/infra/main.bicepparam
@@ -126,7 +126,7 @@ param enableAIGatewayPiiRedaction = bool(readEnvironmentVariable('ENABLE_PII_RED
 param enableOpenAIRealtime = bool(readEnvironmentVariable('ENABLE_OPENAI_REALTIME', 'true'))
 param entraAuth = bool(readEnvironmentVariable('AZURE_ENTRA_AUTH', 'false'))
 param enableAPICenter = bool(readEnvironmentVariable('ENABLE_API_CENTER', 'false'))
-param enableManagedRedis = bool(readEnvironmentVariable('ENABLE_MANAGED_REDIS', 'true'))
+param enableManagedRedis = bool(readEnvironmentVariable('ENABLE_MANAGED_REDIS', 'false'))
 param enableUnifiedAiApi = bool(readEnvironmentVariable('ENABLE_UNIFIED_AI_API', 'true'))
 
 // ============================================================================
@@ -171,6 +171,7 @@ param apicSku = readEnvironmentVariable('APIC_SKU', 'Free')
 param keyVaultSkuName = readEnvironmentVariable('KEY_VAULT_SKU_NAME', 'standard')
 param redisSkuName = readEnvironmentVariable('REDIS_SKU_NAME', 'Balanced_B1')
 param redisSkuCapacity = int(readEnvironmentVariable('REDIS_SKU_CAPACITY', '1'))
+param redisHighAvailability = readEnvironmentVariable('REDIS_HIGH_AVAILABILITY', 'Enabled')
 
 // ============================================================================
 // ACCELERATOR SPECIFIC PARAMETERS

--- a/bicep/infra/modules/redis/redis.bicep
+++ b/bicep/infra/modules/redis/redis.bicep
@@ -77,6 +77,13 @@ param publicNetworkAccess string = 'Disabled'
 @description('Minimum TLS version for Redis connections')
 param minimumTlsVersion string = '1.2'
 
+// Zone redundancy (Enabled) places replicas across availability zones. In capacity-constrained
+// regions this can intermittently fail cluster creation ("CreateFailed") for small Balanced SKUs;
+// set to Disabled to remove the zonal allocation dependency at the cost of the HA SLA.
+@description('High availability / zone redundancy for the Redis cluster. Enabled (default) replicates data across availability zones. Disable to avoid transient zonal capacity allocation failures during creation (reduces availability SLA, no data replication).')
+@allowed(['Enabled', 'Disabled'])
+param highAvailability string = 'Enabled'
+
 @description('Whether to create a private endpoint for Redis')
 param usePrivateEndpoint bool = true
 
@@ -133,6 +140,7 @@ resource redis 'Microsoft.Cache/redisEnterprise@2025-07-01' = {
   properties: {
     minimumTlsVersion: minimumTlsVersion
     publicNetworkAccess: publicNetworkAccess
+    highAvailability: highAvailability
   }
 }
 

--- a/guides/put-estimation-guide.md
+++ b/guides/put-estimation-guide.md
@@ -4,6 +4,8 @@
 > **Scope**: Azure OpenAI / Foundry LLM deployments using **Provisioned Throughput Units (PTUs)** and **Pay‑As‑You‑Go (PAYG)**  
 > **Models**: GPT‑4o, GPT‑5 family (GPT‑5, GPT‑5.1, GPT‑5 mini)
 
+A tool that can be leveraged to do the sizing can be found here: [AzurePTU Sizing Calculator](https://modelavailability.com/tools/azure-ptu-calculator)
+
 ***
 
 ## 1. What a PTU Really Is (and What It Is Not)

--- a/scripts/remove-failed-managed-redis.ps1
+++ b/scripts/remove-failed-managed-redis.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+    Removes an Azure Managed Redis (Microsoft.Cache/redisEnterprise) resource that is stuck in a
+    terminal "Failed" provisioning state before `azd up` / `azd provision` runs.
+
+.DESCRIPTION
+    Azure Managed Redis (Redis Enterprise) can hit a transient create failure that leaves the
+    cluster in provisioningState = "Failed" ("Create failed" in the portal). A subsequent
+    deployment issues an in-place PUT against that failed cluster and the provider rejects it with
+    "A resource with this name already exists or is in a conflicting state.", blocking the whole
+    deployment. Deleting the failed resource and rerunning succeeds.
+
+    This azd preprovision hook automates that recovery. It discovers Redis Enterprise resources
+    tagged for the current azd environment, and deletes ONLY those whose provisioningState is
+    exactly "Failed". Resources that are absent, Creating, Updating, or Succeeded are left
+    untouched, so the hook is a no-op on healthy environments and safe to run on every deployment.
+
+.NOTES
+    Relies on azd-provided environment variables: AZURE_SUBSCRIPTION_ID and AZURE_ENV_NAME.
+#>
+
+$ErrorActionPreference = 'Stop'
+
+$subscriptionId = $env:AZURE_SUBSCRIPTION_ID
+$environmentName = $env:AZURE_ENV_NAME
+
+if ([string]::IsNullOrWhiteSpace($subscriptionId)) {
+    Write-Host 'AZURE_SUBSCRIPTION_ID is not set; skipping failed Managed Redis cleanup.'
+    return
+}
+
+if ([string]::IsNullOrWhiteSpace($environmentName)) {
+    Write-Host 'AZURE_ENV_NAME is not set; skipping failed Managed Redis cleanup.'
+    return
+}
+
+Write-Host "Checking for failed Azure Managed Redis resources in environment '$environmentName'..."
+
+# Note: `az resource list` cannot combine --tag with --resource-type, so filter by tag and
+# narrow to the Redis Enterprise type in the JMESPath query instead.
+$resourceIds = az resource list `
+    --subscription $subscriptionId `
+    --tag "azd-env-name=$environmentName" `
+    --query "[?type=='Microsoft.Cache/redisEnterprise'].id" `
+    --output tsv
+
+if ($LASTEXITCODE -ne 0) {
+    throw 'Failed to list Managed Redis resources.'
+}
+
+if ([string]::IsNullOrWhiteSpace($resourceIds)) {
+    Write-Host 'No Managed Redis resource currently exists for this azd environment. Nothing to clean up.'
+    return
+}
+
+foreach ($resourceId in ($resourceIds -split "`n")) {
+    $resourceId = $resourceId.Trim()
+    if ([string]::IsNullOrWhiteSpace($resourceId)) {
+        continue
+    }
+
+    $provisioningState = az resource show `
+        --ids $resourceId `
+        --query 'properties.provisioningState' `
+        --output tsv
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to read provisioning state for $resourceId"
+    }
+
+    $provisioningState = $provisioningState.Trim()
+
+    if ($provisioningState -eq 'Failed') {
+        Write-Host "Managed Redis '$resourceId' is in a Failed state. Deleting it so the deployment can recreate it..."
+        az resource delete --ids $resourceId | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "Failed to delete the failed Managed Redis resource $resourceId"
+        }
+        Write-Host "Deleted failed Managed Redis '$resourceId'."
+    }
+    else {
+        Write-Host "Managed Redis '$resourceId' is in state '$provisioningState'. Leaving it untouched."
+    }
+}

--- a/scripts/remove-failed-managed-redis.sh
+++ b/scripts/remove-failed-managed-redis.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Removes an Azure Managed Redis (Microsoft.Cache/redisEnterprise) resource that is stuck in a
+# terminal "Failed" provisioning state before `azd up` / `azd provision` runs.
+#
+# Azure Managed Redis (Redis Enterprise) can hit a transient create failure that leaves the
+# cluster in provisioningState = "Failed" ("Create failed" in the portal). A subsequent
+# deployment issues an in-place PUT against that failed cluster and the provider rejects it with
+# "A resource with this name already exists or is in a conflicting state.", blocking the whole
+# deployment. Deleting the failed resource and rerunning succeeds.
+#
+# This azd preprovision hook automates that recovery. It discovers Redis Enterprise resources
+# tagged for the current azd environment, and deletes ONLY those whose provisioningState is
+# exactly "Failed". Resources that are absent, Creating, Updating, or Succeeded are left
+# untouched, so the hook is a no-op on healthy environments and safe to run on every deployment.
+#
+# Relies on azd-provided environment variables: AZURE_SUBSCRIPTION_ID and AZURE_ENV_NAME.
+
+set -euo pipefail
+
+subscription_id="${AZURE_SUBSCRIPTION_ID:-}"
+environment_name="${AZURE_ENV_NAME:-}"
+
+if [ -z "$subscription_id" ]; then
+    echo "AZURE_SUBSCRIPTION_ID is not set; skipping failed Managed Redis cleanup."
+    exit 0
+fi
+
+if [ -z "$environment_name" ]; then
+    echo "AZURE_ENV_NAME is not set; skipping failed Managed Redis cleanup."
+    exit 0
+fi
+
+echo "Checking for failed Azure Managed Redis resources in environment '$environment_name'..."
+
+# Note: `az resource list` cannot combine --tag with --resource-type, so filter by tag and
+# narrow to the Redis Enterprise type in the JMESPath query instead.
+resource_ids="$(az resource list \
+    --subscription "$subscription_id" \
+    --tag "azd-env-name=$environment_name" \
+    --query "[?type=='Microsoft.Cache/redisEnterprise'].id" \
+    --output tsv)"
+
+if [ -z "$resource_ids" ]; then
+    echo "No Managed Redis resource currently exists for this azd environment. Nothing to clean up."
+    exit 0
+fi
+
+while IFS= read -r resource_id; do
+    [ -z "$resource_id" ] && continue
+
+    provisioning_state="$(az resource show \
+        --ids "$resource_id" \
+        --query 'properties.provisioningState' \
+        --output tsv)"
+
+    if [ "$provisioning_state" = "Failed" ]; then
+        echo "Managed Redis '$resource_id' is in a Failed state. Deleting it so the deployment can recreate it..."
+        az resource delete --ids "$resource_id" >/dev/null
+        echo "Deleted failed Managed Redis '$resource_id'."
+    else
+        echo "Managed Redis '$resource_id' is in state '$provisioning_state'. Leaving it untouched."
+    fi
+done <<< "$resource_ids"


### PR DESCRIPTION
This pull request introduces improvements to the deployment and management of Azure Managed Redis resources, focusing on resilience against transient provisioning failures and enhanced configuration flexibility. It adds automated cleanup scripts as preprovision hooks, exposes a new high availability parameter, and updates default deployment parameters for Redis. Additionally, a helpful tool link is added to the PTU estimation guide.

**Azure Managed Redis resilience and configuration:**

* Added preprovision hooks in `azure.yaml` to automatically run scripts (`remove-failed-managed-redis.ps1` for Windows and `remove-failed-managed-redis.sh` for POSIX) that detect and delete only failed Azure Managed Redis resources before provisioning, enabling self-healing deployments when encountering terminal create failures. [[1]](diffhunk://#diff-1ba5bd52036276068bc787a1be3dfa49aa920317ab02fa460c99246a78e588f3R13-R28) [[2]](diffhunk://#diff-62f5f5eb2524003b3efed372ea854ff60327149b028231624fc353516b9a181bR1-R84) [[3]](diffhunk://#diff-015bb6dd4752a101fd368c4416337e8051f9a519ce4f08a8101d46b0886dccf5R1-R64)
* Introduced a new `redisHighAvailability` parameter in `bicep/infra/main.bicep` and `bicep/infra/modules/redis/redis.bicep`, allowing deployments to toggle high availability (zone redundancy) for Redis clusters, with clear documentation on the trade-offs between availability and deployment reliability. [[1]](diffhunk://#diff-f66e545bccaaa3ea3b75756138e4fd95b9d90ea160ed66b18a241269178faf14R394-R397) [[2]](diffhunk://#diff-7e2852ff4aadbd53bff976962dd916e9568935aa6d55c7027955fdc3c276a130R80-R86) [[3]](diffhunk://#diff-7e2852ff4aadbd53bff976962dd916e9568935aa6d55c7027955fdc3c276a130R143)
* Passed the new `redisHighAvailability` parameter through environment variables and deployment modules, enabling environment-specific configuration and easier troubleshooting of capacity-related deployment failures. [[1]](diffhunk://#diff-26d0b4d989e5d37a41f87c721989b0e60ad71e9fa8aaeeddf6cab7dd8d3e08a2R174) [[2]](diffhunk://#diff-f66e545bccaaa3ea3b75756138e4fd95b9d90ea160ed66b18a241269178faf14R943)

**Default deployment parameter changes:**

* Changed the default value of `ENABLE_MANAGED_REDIS` to `false` in `bicep/infra/main.bicepparam`, so managed Redis is opt-in by default.

**Documentation updates:**

* Added a link to the AzurePTU Sizing Calculator in the PTU estimation guide for easier resource sizing.