### PR TITLE
Update documentation for Citadel Governance Hub v1 GA release

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ The **AI Citadel Blueprint** is a unified, layered approach to AI security and c
 |-------|------|----------------|----------------|
 | 🔷 **Layer 1** | **Governance Hub** | Runtime enforcement — unified AI gateway, policy-as-code, identity validation, token rate limiting, content filtering, cost attribution | **👉 This Accelerator** ([aka.ms/ai-hub-gateway](https://aka.ms/ai-hub-gateway)) |
 | 🔶 **Layer 2** | **Agent Operations** | Agent runtime, observability & compliance — agent traces, AI evaluations, fleet operations, automated compliance checks | [Microsoft Foundry Agents & Control Plane](https://learn.microsoft.com/en-us/azure/ai-foundry/control-plane/overview) |
-| 🟢 **Layer 3** | **Agent Identity** | Agent identity & lifecycle governance and security — unique agent identities, blueprints, shadow agent detection, sponsorship model, access packages | [Governing Agent Identities with Agent 365](https://learn.microsoft.com/en-us/microsoft-agent-365/) |
+| 🟢 **Layer 3** | **Agent Management** | Agent identity & lifecycle governance and security — unique agent identities, blueprints, shadow agent detection, sponsorship model, access packages | [Governing Agent Identities with Agent 365](https://learn.microsoft.com/en-us/microsoft-agent-365/) |
 | 🛡️ **Layer 4** | **Security Foundation** | Unified protection — `Microsoft Defender` for AI threat intelligence, `Purview` for data governance, `Entra` for authentication and authorization | Microsoft Defender, Purview & Entra |
 
 The layers are not isolated silos — they form an integrated architecture grounded in the principle of **separation of concerns with unified oversight**.
 
 **Layer 1: Governance Hub** (this accelerator) acts as the runtime gateway through a hub-and-spoke deployment where a centrally managed AI gateway (Azure API Management) enforces runtime policies, while **Layer 2: Agent Operations** spoke environments give each business unit autonomous development within guardrails.
-Adding **Layer 3: Agent Identity** ensures that every agent has a unique, governable identity, while **Layer 4: Security Foundation** provides unified threat protection and data governance across the entire architecture.
+Adding **Layer 3: Agent Management** ensures that every agent has a unique, governable identity, while **Layer 4: Security Foundation** provides unified threat protection and data governance across the entire architecture.
 
 > 📎 For the full Citadel Blueprint approach and guidance, visit: [aka.ms/foundry-citadel](https://aka.ms/foundry-citadel)
 

--- a/README.md
+++ b/README.md
@@ -163,13 +163,13 @@ Leverage **Citadel Access Contracts** to declare the required access to LLMs, to
 
 >NOTE: Recommendation is to create one contract per business-unit/use-case/environment to allow for precise governance policies and better observability in the hub.
 
-#### Publish Contracts
+#### Publish Contracts (Preview)
 
 Leverage **Citadel Publish Contracts** to onboard and publish centrally protected AI assets — **Tools (MCP)** and **Agents (A2A)** — through the gateway with per-asset backends, resiliency, baseline policies, usage tracking, and optional API Center registration.
 
 [Publish contracts](bicep\infra\citadel-publish-contracts\README.md) are infrastructure-as-code declarations of the AI assets published on the gateway. See the [Publish Contract Guide](bicep\infra\citadel-publish-contracts\publish-contract-guide.md) for asset types, backend/auth options, and Foundry A2A publishing.
 
->NOTE: Publishing an asset does not grant access to it — governed access (products/subscriptions) is handled by Access Contracts.
+>NOTE: Publish Contracts and Foundry-hosted A2A publishing are available in Preview (`publish-contract-version: 1.0.0-preview`). Publishing an asset does not grant access to it — governed access (products/subscriptions) is handled by Access Contracts.
 
 #### Existing agents
 
@@ -199,12 +199,13 @@ For detailed guidance and technical implementation, see [AI App Landing Zone Rep
 
 ## 🔄 Governance Hub Operations - Contract-Driven Governance
 
-Day-to-day operation of the Citadel Governance Hub is **contract-driven**: every change to what the gateway serves and who can consume it is declared as version-controlled infrastructure-as-code (`.bicepparam` files) rather than manual portal configuration. Two complementary contract types govern the two sides of the gateway:
+Day-to-day operation of the Citadel Governance Hub is **contract-driven**: every change to what the gateway serves and who can consume it is declared as version-controlled infrastructure-as-code (`.bicepparam` files) rather than manual portal configuration. Three complementary contract types govern the gateway lifecycle:
 
 - **🔌 Backend Contracts** — govern the **supply side**: which LLM backends and models the gateway can route to.
+- **📤 Publish Contracts (Preview)** — govern which Tools (MCP) and Agents (A2A) are published through the gateway.
 - **📝 Access Contracts** — govern the **demand side**: which use cases and agents can consume those models, and under which policies.
 
-Together they create a clean separation of concerns: platform teams curate the available AI capacity once, while business units onboard use cases against that curated capacity without ever touching gateway internals.
+Together they create a clean separation of concerns: platform teams curate AI capacity and published assets, while business units onboard use cases against those governed assets without touching gateway internals.
 
 ```mermaid
 flowchart LR
@@ -212,6 +213,10 @@ flowchart LR
         B1[LLM Backends & Models]
         B2[Load Balancing & Failover]
         B3[Model Aliases]
+    end
+    subgraph Publishing["📤 Publish Contracts (Preview)"]
+        P1[Tools / MCP]
+        P2[Agents / A2A]
     end
     subgraph Gateway["🚪 AI Gateway (APIM)"]
         G1[Routing & Policy Engine]
@@ -221,7 +226,9 @@ flowchart LR
         A2[Per-use-case Policies]
         A3[Foundry / Key Vault Credentials]
     end
-    Supply --> Gateway --> Demand
+    Supply --> Gateway
+    Publishing --> Gateway
+    Gateway --> Demand
 ```
 
 ### 🔌 Backend Contracts — Onboard LLM backends and models
@@ -244,11 +251,11 @@ Declares the governed dependencies an agent or use case needs—LLMs, AI service
 
 > 🔗 **Learn More:** [AI Citadel Access Contracts Guide](./bicep/infra/citadel-access-contracts/README.md)
 
-### 📤 Publish Contracts (Upcoming)
+### 📤 Publish Contracts (Preview)
 
-Describes the tools and agents a spoke exposes **back** to the hub—publishing rules, ownership metadata, security posture, and discovery/cataloging in the AI Registry.
+Publishes Tools (MCP) and Agents (A2A) through the gateway with declarative endpoint and backend configuration, baseline policies, usage tracking, resiliency for supported backend types, and optional Azure API Center registration. Foundry-hosted agents can be exposed as A2A endpoints.
 
->NOTE: Publish contracts are upcoming and will be available in future releases.
+>NOTE: This capability is available in Preview (`publish-contract-version: 1.0.0-preview`). Its contract surface may change before general availability. See the [Publish Contract Guide](./bicep/infra/citadel-publish-contracts/publish-contract-guide.md).
 
 ### ✅ Why Contract-Driven Governance
 
@@ -338,12 +345,13 @@ Master AI Citadel Governance Hub implementation and operations with our detailed
 | [**🆕 APIM Gateway Upgrade Guide**](./bicep/infra/apim-gateway-upgrade/README.md) | Update gateway policies, APIs, backends, diagnostics, and named values on an existing APIM instance without re-provisioning infrastructure |
 | [**🆕 Release Version Management**](./guides/release-version-management.md) | Versioning model of the accelerator, the `/version` runtime endpoint, and how to plan and implement migrations |
 
-### 🔧 **Use-case Onboarding**
+### 🔧 **Operations Contracts**
 
 | Guide | Description |
 |-------|-------------|
 | [**🆕 AI Citadel Access Contracts Guide**](./bicep/infra/citadel-access-contracts/README.md) | Guide on integrating new/existing AI apps & agents with AI Citadel Governance Hub |
 | [**🆕 AI Citadel Access Contracts Policies**](./bicep/infra/citadel-access-contracts/citadel-access-contracts-policy.md) | Deep dive into policy configurations for AI Citadel Access Contracts |
+| [**🆕 AI Citadel Publish Contracts Guide (Preview)**](./bicep/infra/citadel-publish-contracts/README.md) | Guide on publishing Tools (MCP) and Agents (A2A) through the gateway with optional Foundry A2A publishing |
 
 
 ### 🛡️ **Security & Compliance**

--- a/guides/citadel-v1-ga-announcement.md
+++ b/guides/citadel-v1-ga-announcement.md
@@ -1,0 +1,77 @@
+# Citadel Governance Hub v1 GA Announcement Pack
+
+## Full announcement: Citadel Governance Hub v1 is generally available
+
+We are announcing the general availability of **Citadel Governance Hub v1**, the Layer 1 reference implementation of the [AI Citadel Blueprint](https://aka.ms/foundry-citadel).
+
+Citadel Governance Hub is an enterprise AI landing-zone accelerator that provides a centralized, governable, and observable gateway plane for AI consumption. Built on Azure API Management, it gives platform teams a repeatable way to onboard AI backends, enforce runtime policy, provide governed access to applications and agents, and attribute usage across teams and environments.
+
+The accelerator is available from the [Azure Samples repository](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator) and at [aka.ms/ai-hub-gateway](https://aka.ms/ai-hub-gateway).
+
+## GA highlights
+
+### One governed gateway for multi-provider AI
+
+- Unified routing for Microsoft Foundry, Azure OpenAI, Amazon Bedrock, Google Gemini, Anthropic Claude, and OpenAI-compatible providers.
+- Native and OpenAI-compatible API surfaces for chat, embeddings, responses, realtime, and supported image-generation scenarios.
+- Dynamic model discovery and model aliases that decouple client-facing model names from backend deployments.
+
+### Contract-driven onboarding and governance
+
+- **Backend Contracts** declare providers, models, authentication, pools, routing behavior, and resiliency settings as infrastructure-as-code.
+- **Access Contracts** create governed APIM products and subscriptions with model authorization, throttling, quotas, content safety, PII controls, and optional layered JWT authentication.
+- Version-controlled Bicep parameters support repeatable onboarding through pull requests and CI/CD workflows without requiring teams to edit shared gateway policies.
+
+### Resilient routing for production workloads
+
+- Load-balanced backend pools with priority and weighted routing.
+- Circuit breakers, automated failover, retry-aware behavior, and configurable error handling.
+- Session affinity for stateful model workloads that need follow-up requests routed to the same backend.
+- Multi-region and business-continuity guidance for globally deployed governance hubs.
+
+### Security, observability, and cost attribution
+
+- Managed identity for supported Azure service-to-service authentication.
+- Central policy enforcement for content safety, PII handling, API keys, JWT validation, rate limits, and quotas.
+- Application Insights, Log Analytics, Event Hubs, Logic Apps, and Cosmos DB integration for operational and usage telemetry.
+- Power BI reporting for usage analysis, cost allocation, and chargeback by product, application, model, and backend.
+
+### Deployment, operations, and validation
+
+- Bicep-based deployment through Azure Developer CLI, with a separate [Terraform implementation](https://github.com/Azure/terraform-ai-gateway-landing-zone).
+- Quick-start and full deployment paths for evaluation and enterprise landing-zone scenarios.
+- Post-deployment guides for backend onboarding, access contracts, authentication, reporting, resiliency, and business continuity.
+- Validation notebooks covering routing, model aliases, multi-provider access, image models, session affinity, security policies, and agent-framework integration.
+- Runtime release visibility through `GET /version` and active backend-contract visibility through `GET /version/backend-contract`.
+
+## Available in Preview
+
+The following capabilities ship with v1 as functional Preview features. Their configuration surfaces may change before general availability, so pin exact versions and validate changes in a non-production environment:
+
+- **Citadel Publish Contracts `1.0.0-preview`** for publishing Tools (MCP) and Agents (A2A), including Foundry-hosted A2A agents, with baseline policies, usage tracking, supported backend resiliency, and optional Azure API Center registration.
+- **Microsoft Foundry APIM connection and Foundry-hosted A2A integration**, enabling governed agent access and agent publishing through the gateway.
+- **APIM Gateway Upgrade `1.0.0-preview`** for applying gateway capabilities to an existing Citadel or classic AI Hub Gateway deployment without re-provisioning the surrounding landing-zone infrastructure.
+
+## Release versions
+
+| Component | Version | Status |
+|-----------|---------|--------|
+| Citadel Governance Hub | `1.0.2` | GA |
+| Routing | `1.0.0` | GA |
+| Backend Contract | `1.1.0` | GA |
+| Access Contract | `1.2.0` | GA |
+| Usage ingestion | `1.1.0` | GA |
+| Publish Contract | `1.0.0-preview` | Preview |
+| APIM Gateway Upgrade | `1.0.0-preview` | Preview |
+
+## Get started
+
+1. Review the [architecture and capabilities](../README.md).
+2. Use the [Quick Deployment Guide](./quick-deployment-guide.md) for a non-production evaluation or the [Full Deployment Guide](./full-deployment-guide.md) for an enterprise deployment.
+3. Follow the [Post-Deployment Guide](./post-deployment-guide.md) to onboard backends and use cases.
+4. Run the [validation notebooks](../validation/README.md) before promoting the gateway to production.
+5. Review [Release Version Management](./release-version-management.md) before adopting subsequent releases or Preview updates.
+
+We welcome feedback and contributions through the repository's [GitHub issues](https://github.com/Azure-Samples/ai-hub-gateway-solution-accelerator/issues).
+
+---

--- a/guides/governance-hub-benefits.md
+++ b/guides/governance-hub-benefits.md
@@ -178,14 +178,14 @@ Citadel Governance Hub evolves as part of the **Foundry Citadel Platform** visio
 - Content safety enforcements
 - Usage analytics and cost management
 - Citadel Access Contracts support with automated onboarding
+- Citadel Publish Contracts for Tools (MCP) and Agents (A2A) *(Preview)*
+- Microsoft Foundry APIM connection integration and Foundry-hosted A2A publishing *(Preview)*
 - AI Registry for models and tools
 - Authentication support with gateway keys, or gateway keys + JWT tokens
 
 ### Coming soon
-- Microsoft Foundry control plane integration
+- Broader Microsoft Foundry control-plane lifecycle integration beyond the current Preview APIM connection and A2A publishing capabilities
 - AI evaluation pipeline at the gateway level
-- A2A support and agent publishing (AI Gateway + AI Registry integration)
-- Guidance for Citadel Publish Contracts
 - Defender & Purview enablement
 - JWT-only authentication support (without gateway keys)
 - Enhanced platform observability with custom dashboards and alerts (geared towards agents and MCP tools)

--- a/guides/post-deployment-guide.md
+++ b/guides/post-deployment-guide.md
@@ -128,7 +128,7 @@ This pairs with the [Access Contract resiliency feature](../bicep/infra/citadel-
 
 As the accelerator evolves, adopt new releases on an **already-provisioned** gateway using the **APIM Gateway Upgrade** submodule — it applies new policies, APIs, backends, fragments, named values, and the `/version` manifest **in place**, without re-provisioning APIM or the surrounding landing zone.
 
-**Plan the upgrade using version tracks.** The accelerator uses independent, component-scoped versions in [`release.json`](../release.json) (`master-version`, `routing-version`, `backend-contract-version`, `access-contract-version`, `gateway-upgrade-version`, `usage-ingestion-version`). Compare **each** track against what you run today and read the [Release Version Management Guide](./release-version-management.md) migration notes for any `MAJOR` bump.
+**Plan the upgrade using version tracks.** The accelerator uses independent, component-scoped versions in [`release.json`](../release.json) (`master-version`, `routing-version`, `backend-contract-version`, `access-contract-version`, `publish-contract-version`, `gateway-upgrade-version`, `usage-ingestion-version`). Compare **each** track against what you run today and read the [Release Version Management Guide](./release-version-management.md) migration notes for any `MAJOR` bump or Preview track change.
 
 **Confirm what is deployed at runtime** (no source inspection needed):
 
@@ -145,6 +145,8 @@ curl https://<your-apim-gateway-host>/version/backend-contract
 4. Deploy the upgrade, then re-run [Backend Contract onboarding](#1-onboard-llm-backends-backend-contract) if routing fragments changed, and re-check `/version`.
 
 > ⚠️ The `gateway-upgrade-version` track is currently `-preview` — pin to an exact version in production and validate before upgrading.
+
+> ⚠️ The `publish-contract-version` track is also `-preview` — review and validate MCP/A2A contract changes before re-deploying published assets.
 
 📘 Module: [`bicep/infra/apim-gateway-upgrade`](../bicep/infra/apim-gateway-upgrade/README.md) · Guide: [Release Version Management](./release-version-management.md)
 

--- a/guides/release-version-management.md
+++ b/guides/release-version-management.md
@@ -25,12 +25,13 @@ ingestion).
 
 ```jsonc
 {
-    "master-version": "1.0.0",
+    "master-version": "1.0.2",
     "routing-version": "1.0.0",
-    "backend-contract-version": "1.0.0",
-    "access-contract-version": "1.0.0",
+    "backend-contract-version": "1.1.0",
+    "access-contract-version": "1.2.0",
+    "publish-contract-version": "1.0.0-preview",
     "gateway-upgrade-version": "1.0.0-preview",
-    "usage-ingestion-version": "1.0.0"
+    "usage-ingestion-version": "1.1.0"
 }
 ```
 
@@ -54,6 +55,7 @@ optional pre-release suffix (for example `-preview`):
 | **`routing-version`** | The LLM request routing logic — backend pool selection, model-to-backend resolution, load balancing, failover, alias fallback, and the dynamic routing policy fragments. | Changes to `llm-policy-fragments.*`, `llm-backend-pools.bicep`, routing/target policies. | `bicep/infra/modules/apim` |
 | **`backend-contract-version`** | The shape of the **backend configuration contract** (`llmBackendConfig`) consumed during onboarding — backend types, auth types, model object properties, circuit breaker defaults. | Changes to the `llmBackendConfig` schema or `llm-backend-onboarding` parameter surface. | `bicep/infra/llm-backend-onboarding` |
 | **`access-contract-version`** | The shape of the **Citadel Access Contract** — product policies, JWT/subscription access patterns, per-use-case product definitions, and the access-contract parameter surface. | Changes to `citadel-access-contracts` schema, product policy templates, or access-pattern behavior. | `bicep/infra/citadel-access-contracts` |
+| **`publish-contract-version`** | The shape of the **Citadel Publish Contract** for publishing Tools (MCP) and Agents (A2A), including Foundry-hosted A2A agents. Currently `-preview`. | Changes to publish asset schemas, baseline policies, backend/auth options, usage tracking, or API Center integration. | `bicep/infra/citadel-publish-contracts` |
 | **`gateway-upgrade-version`** | The in-place **APIM Gateway Upgrade** tooling used to update an existing gateway without re-provisioning. Currently `-preview`. | Changes to `bicep/infra/apim-gateway-upgrade`. | `bicep/infra/apim-gateway-upgrade` |
 | **`usage-ingestion-version`** | The **usage ingestion pipeline** — Logic App workflows and the usage-ingestion Function that process usage/log streams into the reporting store. | Changes to `src/usage-ingestion-logicapp`, the usage-ingestion function, or the ingestion data contract. | `src/usage-ingestion-*` |
 
@@ -234,6 +236,16 @@ The Citadel Access Contract product/policy surface changed.
 - Re-deploy the access contracts; validate JWT and subscription access patterns per use case with
   the access-contract validation notebooks.
 - See [AI Citadel Access Contracts](../bicep/infra/citadel-access-contracts/README.md).
+
+### `publish-contract-version` (`-preview` / MAJOR)
+
+The Publish Contract surface for MCP and A2A assets is available in Preview and may evolve.
+
+- Pin to the exact Preview version you validated and deploy to a non-production gateway first.
+- Review each Publish Contract parameter file when the schema, baseline policies, backend/auth options,
+  or usage tracking changes; re-deploy affected published assets.
+- Validate MCP handshakes and A2A agent-card/JSON-RPC flows before promotion.
+- See the [Citadel Publish Contract Guide](../bicep/infra/citadel-publish-contracts/publish-contract-guide.md).
 
 ### `gateway-upgrade-version` (`-preview`)
 


### PR DESCRIPTION
This pull request updates the documentation to announce the general availability (GA) of Citadel Governance Hub v1 and introduces the new Citadel Publish Contracts (Preview) feature for publishing Tools (MCP) and Agents (A2A) through the gateway. It also updates version references, clarifies contract-driven governance, and adds guidance for managing Preview features. The changes provide clear separation of contract types, describe the Preview status of Publish Contracts, and add a comprehensive GA announcement guide.

The most important changes are:

**Citadel Publish Contracts (Preview) Feature:**
* Introduced and documented the new "Publish Contracts (Preview)" for publishing Tools (MCP) and Agents (A2A) through the gateway, with baseline policies, usage tracking, resiliency, and optional Azure API Center registration. Clarified its Preview status and provided guidance links. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R172) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L202-R208) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L247-R258) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L341-R354) [[5]](diffhunk://#diff-1e791059191f805ebbef2e82cd00f0f35fe3f2f13e6a5be55c4706e50f89270dR181-L188)
* Updated diagrams and governance explanations to include Publish Contracts as a distinct contract type alongside Backend and Access Contracts. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R217-R220) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L224-R231)

**General Availability Announcement:**
* Added a new announcement guide `guides/citadel-v1-ga-announcement.md` detailing the GA release, highlights, Preview features, and versioning for all Citadel Governance Hub components.

**Versioning and Upgrade Guidance:**
* Updated version numbers for all major components in documentation and examples (`release.json`) to reflect the GA release and Preview status of new features.
* Added the new `publish-contract-version` to version tracking, upgrade planning, and release management documentation, with instructions for handling Preview features and validating changes before production deployment. [[1]](diffhunk://#diff-a7c5d82d100cb98696dc432287e894efb5b935d04870ebea0fbbdf4245215390L131-R131) [[2]](diffhunk://#diff-a7c5d82d100cb98696dc432287e894efb5b935d04870ebea0fbbdf4245215390R149-R150) [[3]](diffhunk://#diff-ed769341ffb5756e80724381d8cf851f218db570a86d34488ebbd861d966b4c1R58) [[4]](diffhunk://#diff-ed769341ffb5756e80724381d8cf851f218db570a86d34488ebbd861d966b4c1R240-R249)

**Terminology and Thematic Clarifications:**
* Renamed "Agent Identity" to "Agent Management" in the Citadel Blueprint for clarity.
* Updated section headings and contract descriptions to reflect the expanded scope and new contract types.

These updates ensure that users are aware of the new GA status, understand the Preview nature of Publish Contracts, and have clear guidance for version management and onboarding.