### PR TITLE
Add private-only deployment support for the usage-ingestion Logic App

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ AI Citadel Governance Hub follows a **Central-Control-Plane** with decentralized
 
 Detailed networking approach guidance for Citadel Governance Hub can be found in the [Network Approach Guide](./guides/network-approach.md).
 
+Initial deployments support optional [private-only Logic App website and SCM/Kudu access](./guides/network-approach.md#logic-app-private-connectivity). This is opt-in; defaults remain public access enabled with no Logic App private endpoint.
+
 Below is a high-level overview of the two supported deployment approaches:
 
 #### Part of spoke network (peered to a hub VNet in the connectivity subscription)

--- a/bicep/infra/main.bicep
+++ b/bicep/infra/main.bicep
@@ -210,6 +210,9 @@ param keyVaultPrivateEndpointName string = ''
 @description('Azure Managed Redis private endpoint name. Leave blank to use default naming conventions.')
 param redisPrivateEndpointName string = ''
 
+@description('Logic App private endpoint name. Leave blank to use default naming conventions.')
+param logicAppPrivateEndpointName string = ''
+
 // Services network access configuration
 
 @description('Network type for API Management service. Applies only to Premium and Developer SKUs.')
@@ -221,6 +224,12 @@ param apimV2UsePrivateEndpoint bool = true
 
 @description('API Management service external network access. When false, APIM must have private endpoint.')
 param apimV2PublicNetworkAccess bool = true
+
+@description('Create a private endpoint for the Logic App. Existing VNets require existingPrivateDnsZones.logicApp or dnsZoneRG for privatelink.azurewebsites.net, with DNS links or forwarding configured.')
+param logicAppUsePrivateEndpoint bool = false
+
+@description('Allow public network access to the Logic App. When false, website and SCM access require a working private endpoint and private DNS; workflow publishing must run from a connected network.')
+param logicAppPublicNetworkAccess bool = true
 
 @description('Cosmos DB public network access.')
 @allowed([ 'Enabled', 'Disabled' ])
@@ -622,9 +631,12 @@ module resources './resources.bicep' = {
     aiFoundryPrivateEndpointName: aiFoundryPrivateEndpointName
     keyVaultPrivateEndpointName: keyVaultPrivateEndpointName
     redisPrivateEndpointName: redisPrivateEndpointName
+    logicAppPrivateEndpointName: logicAppPrivateEndpointName
     apimNetworkType: apimNetworkType
     apimV2UsePrivateEndpoint: apimV2UsePrivateEndpoint
     apimV2PublicNetworkAccess: apimV2PublicNetworkAccess
+    logicAppUsePrivateEndpoint: logicAppUsePrivateEndpoint
+    logicAppPublicNetworkAccess: logicAppPublicNetworkAccess
     cosmosDbPublicAccess: cosmosDbPublicAccess
     eventHubNetworkAccess: eventHubNetworkAccess
     aiFoundryExternalNetworkAccess: aiFoundryExternalNetworkAccess

--- a/bicep/infra/main.bicepparam
+++ b/bicep/infra/main.bicepparam
@@ -90,6 +90,7 @@ param existingPrivateDnsZones = {
   apimGateway: readEnvironmentVariable('EXISTING_DNS_ZONE_APIM', '')           // privatelink.azure-api.net
   aiServices: readEnvironmentVariable('EXISTING_DNS_ZONE_AI_SERVICES', '')     // privatelink.services.azure.com
   redis: readEnvironmentVariable('EXISTING_DNS_ZONE_REDIS', '')                // privatelink.redis.azure.net
+  logicApp: readEnvironmentVariable('EXISTING_DNS_ZONE_LOGIC_APP', '')
 }
 
 // Private Endpoint names
@@ -103,11 +104,14 @@ param apimV2PrivateEndpointName = readEnvironmentVariable('APIM_V2_PE_NAME', '')
 param aiFoundryPrivateEndpointName = readEnvironmentVariable('AI_FOUNDRY_PE_NAME', '')
 param keyVaultPrivateEndpointName = readEnvironmentVariable('KEY_VAULT_PE_NAME', '')
 param redisPrivateEndpointName = readEnvironmentVariable('REDIS_PE_NAME', '')
+param logicAppPrivateEndpointName = readEnvironmentVariable('LOGIC_APP_PE_NAME', '')
 
 // Services network access configuration
 param apimNetworkType = readEnvironmentVariable('APIM_NETWORK_TYPE', 'External')
 param apimV2UsePrivateEndpoint = bool(readEnvironmentVariable('APIM_V2_USE_PRIVATE_ENDPOINT', 'true'))
 param apimV2PublicNetworkAccess = bool(readEnvironmentVariable('APIM_V2_PUBLIC_NETWORK_ACCESS', 'true'))
+param logicAppUsePrivateEndpoint = bool(readEnvironmentVariable('LOGIC_APP_USE_PRIVATE_ENDPOINT', 'false'))
+param logicAppPublicNetworkAccess = bool(readEnvironmentVariable('LOGIC_APP_PUBLIC_NETWORK_ACCESS', 'true'))
 param cosmosDbPublicAccess = readEnvironmentVariable('COSMOS_DB_PUBLIC_ACCESS', 'Disabled')
 param eventHubNetworkAccess = readEnvironmentVariable('EVENTHUB_NETWORK_ACCESS', 'Enabled')
 param aiFoundryExternalNetworkAccess = readEnvironmentVariable('AI_FOUNDRY_EXTERNAL_NETWORK_ACCESS', 'Disabled')

--- a/bicep/infra/modules/logicapp/logicapp.bicep
+++ b/bicep/infra/modules/logicapp/logicapp.bicep
@@ -21,6 +21,12 @@ param cosmosDbAccountName string
 
 param functionAppSubnetId string
 
+param logicAppUsePrivateEndpoint bool = false
+param logicAppPublicNetworkAccess bool = true
+param logicAppPrivateEndpointName string = ''
+param privateEndpointSubnetId string = ''
+param dnsZoneResourceId string = ''
+
 param dotnetFrameworkVersion string = 'v6.0'
 
 var docDbAccNativeContributorRoleDefinitionId = '00000000-0000-0000-0000-000000000002'
@@ -84,8 +90,26 @@ resource logicApp 'Microsoft.Web/sites@2024-04-01' = {
   properties: {
     enabled: true
     serverFarmId: hostingPlan.id
+    publicNetworkAccess: logicAppPublicNetworkAccess ? 'Enabled' : 'Disabled'
     reserved: isReserved       
     virtualNetworkSubnetId: functionAppSubnetId
+  }
+}
+
+module privateEndpoint '../networking/private-endpoint.bicep' = if (logicAppUsePrivateEndpoint) {
+  name: '${logicAppName}-pe'
+  params: {
+    groupIds: [
+      'sites'
+    ]
+    dnsZoneName: 'privatelink.azurewebsites.net'
+    name: logicAppPrivateEndpointName
+    privateLinkServiceId: logicApp.id
+    location: location
+    privateEndpointSubnetId: privateEndpointSubnetId
+    dnsZoneResourceId: dnsZoneResourceId
+    enableDnsIntegration: true
+    tags: tags
   }
 }
 
@@ -108,7 +132,6 @@ resource functionAppSiteConfig 'Microsoft.Web/sites/config@2024-04-01' = {
     minTlsVersion: '1.2'
     scmMinTlsVersion: '1.2'
     minimumElasticInstanceCount: 1
-    publicNetworkAccess: 'Enabled'  
     functionsRuntimeScaleMonitoringEnabled: true
     netFrameworkVersion: dotnetFrameworkVersion
     preWarmedInstanceCount: 1

--- a/bicep/infra/resources.bicep
+++ b/bicep/infra/resources.bicep
@@ -207,6 +207,9 @@ param keyVaultPrivateEndpointName string = ''
 @description('Azure Managed Redis private endpoint name. Leave blank to use default naming conventions.')
 param redisPrivateEndpointName string = ''
 
+@description('Logic App private endpoint name. Leave blank to use default naming conventions.')
+param logicAppPrivateEndpointName string = ''
+
 // Services network access configuration
 
 @description('Network type for API Management service. Applies only to Premium and Developer SKUs.')
@@ -218,6 +221,12 @@ param apimV2UsePrivateEndpoint bool = true
 
 @description('API Management service external network access. When false, APIM must have private endpoint.')
 param apimV2PublicNetworkAccess bool = true
+
+@description('Create a private endpoint for the Logic App. Existing VNets require existingPrivateDnsZones.logicApp or dnsZoneRG for privatelink.azurewebsites.net, with DNS links or forwarding configured.')
+param logicAppUsePrivateEndpoint bool = false
+
+@description('Allow public network access to the Logic App. When false, website and SCM access require a working private endpoint and private DNS; workflow publishing must run from a connected network.')
+param logicAppPublicNetworkAccess bool = true
 
 @description('Cosmos DB public network access.')
 @allowed([ 'Enabled', 'Disabled' ])
@@ -679,6 +688,7 @@ var aiCogntiveServicesDnsZoneName = 'privatelink.cognitiveservices.azure.com'
 var apimV2SkuDnsZoneName = 'privatelink.azure-api.net'
 var aiServicesDnsZoneName = 'privatelink.services.ai.azure.com'
 var redisPrivateDnsZoneName = 'privatelink.redis.azure.net'
+var logicAppPrivateDnsZoneName = 'privatelink.azurewebsites.net'
 
 // AI Foundry requires 3 DNS zones for full private endpoint support
 var aiFoundryDnsZoneNames = [
@@ -702,6 +712,10 @@ var existingApimGatewayDnsZoneId = existingPrivateDnsZones.?apimGateway ?? ''
 var existingAiServicesDnsZoneId = existingPrivateDnsZones.?aiServices ?? ''
 var existingOpenAiDnsZoneId = existingPrivateDnsZones.?openai ?? ''
 var existingRedisDnsZoneId = existingPrivateDnsZones.?redis ?? ''
+var existingLogicAppDnsZoneId = existingPrivateDnsZones.?logicApp ?? ''
+
+var createLogicAppDnsZone = logicAppUsePrivateEndpoint && !useExistingVnet && empty(existingLogicAppDnsZoneId) && empty(dnsZoneRG)
+var logicAppPrivateDnsZoneResourceId = !empty(existingLogicAppDnsZoneId) ? existingLogicAppDnsZoneId : (!empty(dnsZoneRG) ? resourceId(!empty(dnsSubscriptionId) ? dnsSubscriptionId : subscription().subscriptionId, dnsZoneRG, 'Microsoft.Network/privateDnsZones', logicAppPrivateDnsZoneName) : (createLogicAppDnsZone ? resourceId('Microsoft.Network/privateDnsZones', logicAppPrivateDnsZoneName) : ''))
 
 // Existing DNS zone resource IDs for AI Foundry (for BYO network scenarios)
 var aiFoundryDnsZoneResourceIds = union(
@@ -730,8 +744,12 @@ var baseDnsZoneNames = [
   redisPrivateDnsZoneName
 ]
 
-// Only include Azure Monitor DNS zone when Private Link Scope is enabled
-var privateDnsZoneNames = useAzureMonitorPrivateLinkScope ? concat(baseDnsZoneNames, [monitorPrivateDnsZoneName]) : baseDnsZoneNames
+// Only include optional DNS zones when their private connectivity is enabled
+var privateDnsZoneNames = concat(
+  baseDnsZoneNames,
+  useAzureMonitorPrivateLinkScope ? [monitorPrivateDnsZoneName] : [],
+  createLogicAppDnsZone ? [logicAppPrivateDnsZoneName] : []
+)
 
 module dnsDeployment './modules/networking/dns.bicep' = [for privateDnsZoneName in privateDnsZoneNames: if(!useExistingVnet) {
   name: 'dns-deployment-${privateDnsZoneName}'
@@ -1108,6 +1126,11 @@ module logicApp './modules/logicapp/logicapp.bicep' = {
     eventHubPIIName: eventHub.outputs.eventHubPIIName
     apimAppInsightsName: monitoring.outputs.apimApplicationInsightsName
     functionAppSubnetId: useExistingVnet ? vnetExisting.outputs.functionAppSubnetId : vnet.outputs.functionAppSubnetId
+    logicAppUsePrivateEndpoint: logicAppUsePrivateEndpoint
+    logicAppPublicNetworkAccess: logicAppPublicNetworkAccess
+    logicAppPrivateEndpointName: !empty(logicAppPrivateEndpointName) ? logicAppPrivateEndpointName : '${abbrs.logicWorkflows}pe-${resourceToken}'
+    privateEndpointSubnetId: useExistingVnet ? vnetExisting!.outputs.privateEndpointSubnetId : vnet!.outputs.privateEndpointSubnetId
+    dnsZoneResourceId: logicAppPrivateDnsZoneResourceId
     fileShareName: logicContentShareName
   }
 }

--- a/bicep/infra/resources.bicepparam
+++ b/bicep/infra/resources.bicepparam
@@ -89,6 +89,7 @@ param existingPrivateDnsZones = {
   apimGateway: readEnvironmentVariable('EXISTING_DNS_ZONE_APIM', '')           // privatelink.azure-api.net
   aiServices: readEnvironmentVariable('EXISTING_DNS_ZONE_AI_SERVICES', '')     // privatelink.services.azure.com
   redis: readEnvironmentVariable('EXISTING_DNS_ZONE_REDIS', '')                // privatelink.redis.azure.net
+  logicApp: readEnvironmentVariable('EXISTING_DNS_ZONE_LOGIC_APP', '')
 }
 
 // Private Endpoint names
@@ -102,11 +103,14 @@ param apimV2PrivateEndpointName = readEnvironmentVariable('APIM_V2_PE_NAME', '')
 param aiFoundryPrivateEndpointName = readEnvironmentVariable('AI_FOUNDRY_PE_NAME', '')
 param keyVaultPrivateEndpointName = readEnvironmentVariable('KEY_VAULT_PE_NAME', '')
 param redisPrivateEndpointName = readEnvironmentVariable('REDIS_PE_NAME', '')
+param logicAppPrivateEndpointName = readEnvironmentVariable('LOGIC_APP_PE_NAME', '')
 
 // Services network access configuration
 param apimNetworkType = readEnvironmentVariable('APIM_NETWORK_TYPE', 'External')
 param apimV2UsePrivateEndpoint = bool(readEnvironmentVariable('APIM_V2_USE_PRIVATE_ENDPOINT', 'true'))
 param apimV2PublicNetworkAccess = bool(readEnvironmentVariable('APIM_V2_PUBLIC_NETWORK_ACCESS', 'true'))
+param logicAppUsePrivateEndpoint = bool(readEnvironmentVariable('LOGIC_APP_USE_PRIVATE_ENDPOINT', 'false'))
+param logicAppPublicNetworkAccess = bool(readEnvironmentVariable('LOGIC_APP_PUBLIC_NETWORK_ACCESS', 'true'))
 param cosmosDbPublicAccess = readEnvironmentVariable('COSMOS_DB_PUBLIC_ACCESS', 'Disabled')
 param eventHubNetworkAccess = readEnvironmentVariable('EVENTHUB_NETWORK_ACCESS', 'Enabled')
 param aiFoundryExternalNetworkAccess = readEnvironmentVariable('AI_FOUNDRY_EXTERNAL_NETWORK_ACCESS', 'Disabled')

--- a/guides/full-deployment-guide.md
+++ b/guides/full-deployment-guide.md
@@ -441,7 +441,7 @@ param eventHubNetworkAccess = 'Enabled'  // Required during deployment of APIM v
 - ✅ Virtual Network with subnets
 - ✅ Network Security Groups
 - ✅ Private DNS Zones
-- ✅ Private Endpoints for all services
+- ✅ Private endpoints according to each service's configuration; the Logic App endpoint is opt-in
 - ✅ Route tables (needed for APIM Developer and Premium SKUs)
 
 ---
@@ -475,6 +475,7 @@ param dnsSubscriptionId = '00000000-0000-0000-0000-000000000000'
 4. NSG required rules configured for APIM subnet
 
 **Required DNS Zones:**
+- `privatelink.azurewebsites.net` when `logicAppUsePrivateEndpoint = true`; supply `existingPrivateDnsZones.logicApp` or reuse the zone through `dnsZoneRG` / `dnsSubscriptionId`, with links or forwarding configured (see [Logic App DNS selection](./network-approach.md#logic-app-private-connectivity)).
 - `privatelink.vaultcore.azure.com`
 - `privatelink.monitor.azure.com`
 - `privatelink.servicebus.windows.net`
@@ -958,6 +959,8 @@ param apimV2UsePrivateEndpoint = true
 param apimV2PublicNetworkAccess = false
 
 // Service Network Access
+param logicAppUsePrivateEndpoint = true
+param logicAppPublicNetworkAccess = false
 param cosmosDbPublicAccess = 'Disabled'
 param eventHubNetworkAccess = 'Disabled'  // Enable during deployment, disable after for APIM Standardv2 and PremiumV2 SKUs
 
@@ -972,6 +975,22 @@ param eventHubNetworkAccess = 'Disabled'  // Enable during deployment, disable a
 It is recommended to leverage Azure Developer CLI (`azd`) for simplified deployments of both the infrastructure and application (Logic Apps workflows).
 
 Based on the configured parameter files, you can deploy using either `az deployment sub create` or `azd up`.
+
+### Private-only Logic App publishing
+
+The Logic App defaults remain `logicAppUsePrivateEndpoint = false` and `logicAppPublicNetworkAccess = true`. To deploy it with private-only website and SCM/Kudu access, use the two overrides in the production example above, or their environment-variable equivalents in the [parameter reference](./parameters-usage-guide.md#logic-app-private-access).
+
+Infrastructure provisioning uses Azure Resource Manager; workflow publishing connects to the app's SCM endpoint. A successful infrastructure deployment does not prove that the publishing machine can reach SCM. Before publishing with public access disabled:
+
+1. Prepare a workstation or self-hosted CI runner in the VNet or a connected network, with routing and HTTPS access to the private endpoint. Ordinary Cloud Shell and public hosted runners should not be assumed to have this access.
+2. Configure private DNS links or forwarding so both `<app>.azurewebsites.net` and `<app>.scm.azurewebsites.net` resolve to the private endpoint IP from that machine. For an existing VNet, supply the existing zone ID or `dnsZoneRG`; see [DNS selection and ownership](./network-approach.md#logic-app-private-connectivity).
+3. Confirm endpoint approval and private DNS/connectivity after provisioning, then publish workflows from that connected machine using the required deployment credentials and permissions. Private networking does not bypass authentication.
+
+For `azd up`, the application deployment phase runs from the machine invoking it, which therefore needs private SCM access. When using separate provisioning and application deployment steps, run the publishing step from the connected machine. This prerequisite also applies to separate workflow publishing after a direct Bicep deployment, including the existing-resource-group path below.
+
+A new deployment can start private-only; temporarily enabling public access is not required when the private publishing path is ready. Setting both flags to `true` is an optional staged-verification mode only when policy permits. It is not an instruction to rerun the full accelerator against an existing hub.
+
+The main and resource-group templates are for initial deployment. Converting an existing app requires a separately reviewed, narrowly scoped maintenance change; these flags are not added to the gateway-upgrade supporting-services templates. Network changes may restart an existing app or delay ingestion. Do not change other services' access settings just to publish the Logic App. See [post-deployment private connectivity checks](./post-deployment-guide.md#logic-app-private-connectivity-checks).
 
 ### Using `az deployment sub create`:
 
@@ -999,6 +1018,8 @@ az deployment sub create \
 
 >Note: Using `az deployment sub create` will only provision the infrastructure. You still will need to deploy the `Logic App` workflows separately after the infrastructure is ready.
 
+> With Logic App public access disabled, that separate workflow publishing step requires [private SCM connectivity](#private-only-logic-app-publishing).
+
 ### Using `azd up`:
 
 This automatically picks up the `main.bicepparam` file. You can override specific parameters using environment variables or by modifying the `main.bicepparam` file directly.
@@ -1016,6 +1037,8 @@ azd up
 ```
 
 >NOTE: Using `azd up` will use the `main.bicepparam` file for parameter values. You can modify it or set environment variables to override specific parameters. This command provisions the infrastructure and deploys the Logic App workflows in one step.
+
+> With Logic App public access disabled, run this command from a machine that meets the [private publishing prerequisites](#private-only-logic-app-publishing).
 
 ### Existing Resource Group Deployment Execution
 

--- a/guides/network-approach.md
+++ b/guides/network-approach.md
@@ -246,7 +246,7 @@ param apimV2UsePrivateEndpoint = true
 - ✅ Virtual Network with subnets (APIM, Private Endpoints, Function App, **Agent** when network injection enabled)
 - ✅ Network Security Groups (one per subnet)
 - ✅ Private DNS Zones
-- ✅ Private Endpoints for all services
+- ✅ Private endpoints according to each service's configuration; the Logic App endpoint is opt-in
 - ✅ Route table (needed for APIM Developer and Premium SKUs)
 - ✅ Agent subnet delegated to `Microsoft.App/environments` for AI Foundry network injection
 
@@ -348,7 +348,7 @@ properties: {
 
 ### Logic App Subnet
 
-Dedicated subnet with `/26` or larger, delegated to `Microsoft.Web/serverFarms`:
+Dedicated subnet for **outbound VNet integration**, with `/26` or larger, delegated to `Microsoft.Web/serverFarms`. The optional inbound private endpoint uses the separate [Private Endpoints Subnet](#private-endpoints-subnet), not this delegated subnet:
 
 ```bicep
 {
@@ -385,7 +385,39 @@ Dedicated subnet with `/26` or larger for all private endpoints:
 }
 ```
 
-> For APIM V2 SKUs, private endpoints in this subnet enable private inbound connectivity.
+> For APIM V2 SKUs and the Logic App (when `logicAppUsePrivateEndpoint = true`), private endpoints in this subnet enable private inbound connectivity.
+
+### Logic App Private Connectivity
+
+Logic App private connectivity is opt-in. The defaults are `logicAppUsePrivateEndpoint = false` and `logicAppPublicNetworkAccess = true`. For private-only access, set the flags to `true` and `false`, respectively. See the [parameter reference](./parameters-usage-guide.md#logic-app-private-access) for environment variables, endpoint naming, and all four flag combinations.
+
+**Website and SCM/Kudu**
+
+One private endpoint with the `sites` subresource serves both the website and SCM/Kudu publishing endpoint. Its private DNS zone group manages these records in `privatelink.azurewebsites.net`:
+
+| Record | Target |
+|--------|--------|
+| `<app>` | Logic App private endpoint IP |
+| `<app>.scm` | Same private endpoint IP |
+
+Continue using `<app>.azurewebsites.net` and `<app>.scm.azurewebsites.net` for HTTPS, not the IP address or private-link hostnames. A second SCM endpoint, separate SCM DNS zone, and manual duplicate records are not needed when using the zone group. See [App Service private endpoint DNS](https://learn.microsoft.com/azure/app-service/overview-private-endpoint#dns).
+
+**DNS selection and ownership**
+
+When the Logic App endpoint is enabled, DNS selection follows this order:
+
+1. Use the resource ID in `existingPrivateDnsZones.logicApp` when supplied.
+2. Otherwise, reuse `privatelink.azurewebsites.net` in `dnsZoneRG`, using `dnsSubscriptionId` or the deployment subscription when that subscription setting is blank.
+3. Otherwise, for a **new VNet**, create the zone locally and link it to the new VNet.
+4. For an **existing VNet** without either DNS input, no zone is created and the endpoint's DNS zone group is skipped. The template does not reject this incomplete DNS configuration.
+
+Reused zones are not automatically linked by this Logic App configuration, even with a new VNet. Ensure the deployment identity can associate the endpoint with the selected zone, and have the network/DNS owner configure links or forwarding for the app network, publishing runners, and administration clients. VNet peering alone does not provide DNS resolution. Reuse a centrally managed zone where applicable rather than creating a conflicting zone for the same namespace.
+
+**Publishing and runtime connectivity**
+
+With public access disabled, website and SCM access require a working private endpoint and private DNS. Publishing runners and administration clients must have private network reachability; see [private-only workflow publishing](./full-deployment-guide.md#private-only-logic-app-publishing). Private connectivity does not replace authentication or authorization.
+
+These flags only control Logic App inbound access. Outbound VNet integration, routing settings, storage, Event Hub, Cosmos DB, monitoring connections, identities, and other services' access settings are unchanged. Keep those dependencies reachable for usage ingestion. This configuration applies to the main/resource-group initial-deployment templates, not the separate gateway-upgrade supporting-services templates.
 
 ---
 
@@ -544,18 +576,23 @@ All zones must be linked to your VNet:
 | `privatelink.queue.core.windows.net` | Storage Queue |
 | `privatelink.azure-api.net` | APIM V2 SKUs |
 | `privatelink.services.ai.azure.com` | Azure AI Foundry |
+| `privatelink.azurewebsites.net` | Logic App website and SCM/Kudu, when `logicAppUsePrivateEndpoint = true` |
 
 > **Azure Monitor:** Requires special Private Link Scope configuration post-deployment for centralized monitoring.
 
+> **Logic App:** Local creation and linking are conditional. For an existing VNet or reused zone, follow [DNS selection and ownership](#logic-app-private-connectivity).
+
 ## Azure services network access settings
 
-Although the accelerator deploys services with private endpoints by default with disabled public access, some services may require specific network access settings to be configured based on your network architecture and security requirements.
+Private endpoint and public network access defaults vary by service. A private endpoint does not automatically disable public access. The Logic App defaults to public access enabled with no template-created private endpoint; configure each service according to your network architecture and security requirements.
 
 | Service | Parameter | Default | Allowed Values | Description |
 |---------|-----------|---------|----------------|-------------|
 | **API Management (Developer/Premium)** | `apimNetworkType` | `External` | `External`, `Internal` | Network type for APIM VNet injection. `Internal` mode requires custom DNS configuration. |
 | **API Management (StandardV2/PremiumV2)** | `apimV2UsePrivateEndpoint` | `true` | `true`, `false` | Enable private endpoint for inbound connectivity on V2 SKUs. |
 | **API Management (StandardV2/PremiumV2)** | `apimV2PublicNetworkAccess` | `true` | `true`, `false` | Allow public network access. Set to `false` to restrict to private endpoint only. |
+| **Logic App** | `logicAppUsePrivateEndpoint` | `false` | `true`, `false` | Create an inbound private endpoint for website and SCM/Kudu access. |
+| **Logic App** | `logicAppPublicNetworkAccess` | `true` | `true`, `false` | Allow public website and SCM/Kudu access. Set to `false` only with working private connectivity and DNS. |
 | **Cosmos DB** | `cosmosDbPublicAccess` | `Disabled` | `Enabled`, `Disabled` | Public network access for Cosmos DB. Keep `Disabled` for secure deployments. |
 | **Event Hub** | `eventHubNetworkAccess` | `Enabled` | `Enabled`, `Disabled` | Public network access. Note: Must be `Enabled` during initial provisioning for APIM V2 SKUs. |
 | **AI Foundry** | `aiFoundryExternalNetworkAccess` | `Disabled` | `Enabled`, `Disabled` | External network access for the AI Foundry / AI Services resources (also serves Content Safety and Language / PII APIs from the **primary** Foundry account). |
@@ -568,6 +605,8 @@ Although the accelerator deploys services with private endpoints by default with
 param apimNetworkType = 'Internal'
 param apimV2UsePrivateEndpoint = true
 param apimV2PublicNetworkAccess = false
+param logicAppUsePrivateEndpoint = true
+param logicAppPublicNetworkAccess = false
 param cosmosDbPublicAccess = 'Disabled'
 param eventHubNetworkAccess = 'Disabled'  // Set after initial deployment
 param aiFoundryExternalNetworkAccess = 'Disabled'
@@ -577,4 +616,5 @@ param useAzureMonitorPrivateLinkScope = true
 > **Important Notes:**
 > - Event Hub must have public access `Enabled` during initial deployment when using APIM V2 SKUs. You can disable it post-deployment.
 > - When `apimNetworkType = 'Internal'`, ensure proper DNS configuration for APIM endpoints.
+> - Private-only Logic App workflow publishing requires a connected runner with private SCM DNS resolution; infrastructure provisioning alone does not publish workflows.
 > - Azure Monitor Private Link Scope requires additional post-deployment configuration for centralized monitoring as Azure Monitor private link scope is a global resource and impact all Log Analytics and Application Insights workspaces across subscriptions when connecting to the same hub network.

--- a/guides/parameters-usage-guide.md
+++ b/guides/parameters-usage-guide.md
@@ -182,6 +182,51 @@ param foundryNetworkInjectionEnabled = true
 param agentSubnetPrefix = '10.170.0.192/26'
 ```
 
+##### Logic App Private Access
+
+The usage-ingestion Logic App supports optional inbound private connectivity. Defaults remain unchanged: no template-created Logic App private endpoint and public network access enabled. These settings are available in both [main.bicepparam](../bicep/infra/main.bicepparam) and [resources.bicepparam](../bicep/infra/resources.bicepparam); custom environment parameter files must include any overrides explicitly.
+
+**Private Endpoint names**
+
+| Parameter | Environment Variable | Default | Description |
+|-----------|----------------------|---------|-------------|
+| `logicAppPrivateEndpointName` | `LOGIC_APP_PE_NAME` | `''` | Optional endpoint resource name. Empty uses `logic-pe-${resourceToken}`. |
+
+**Services network access configuration**
+
+| Parameter | Environment Variable | Default | Description |
+|-----------|----------------------|---------|-------------|
+| `logicAppUsePrivateEndpoint` | `LOGIC_APP_USE_PRIVATE_ENDPOINT` | `false` | Create a Logic App private endpoint in the existing private-endpoint subnet. |
+| `logicAppPublicNetworkAccess` | `LOGIC_APP_PUBLIC_NETWORK_ACCESS` | `true` | Allow public website and SCM/Kudu access, subject to authentication and other access controls. |
+
+**Existing Private DNS Zones**
+
+| Setting | Environment Variable | Default | Description |
+|---------|----------------------|---------|-------------|
+| `existingPrivateDnsZones.logicApp` | `EXISTING_DNS_ZONE_LOGIC_APP` | `''` | Resource ID of an existing `privatelink.azurewebsites.net` zone. Takes precedence over `dnsZoneRG` / `dnsSubscriptionId`. |
+
+The two Boolean flags are independent:
+
+| `logicAppUsePrivateEndpoint` | `logicAppPublicNetworkAccess` | Result |
+|------------------------------|-------------------------------|--------|
+| `false` | `true` | Default: public access enabled; no template-created endpoint. |
+| `true` | `true` | Private and public access enabled; optional staged verification when policy permits. |
+| `true` | `false` | Private-only website and SCM access; private connectivity and DNS are required for workflow publishing. |
+| `false` | `false` | Public access disabled without a template-created endpoint. Requires a working externally managed endpoint and DNS for website/SCM access. |
+
+The templates do not reject the last combination or enforce DNS readiness. For an existing VNet, supply the Logic App zone ID or `dnsZoneRG`, and configure zone links or forwarding. See [Logic App networking](./network-approach.md#logic-app-private-connectivity) for DNS selection and subnet details.
+
+For a private-only initial deployment, set these values in the azd environment file described above:
+
+```dotenv
+LOGIC_APP_USE_PRIVATE_ENDPOINT="true"
+LOGIC_APP_PUBLIC_NETWORK_ACCESS="false"
+```
+
+For a reused DNS zone, also set `EXISTING_DNS_ZONE_LOGIC_APP` to its resource ID; set `LOGIC_APP_PE_NAME` only when overriding the generated endpoint name. A new VNet can use automatic local zone creation when neither a zone ID nor `dnsZoneRG` is supplied.
+
+These settings apply to the main/resource-group initial-deployment templates, not the separate APIM gateway-upgrade supporting-services templates. Before deploying workflows with public access disabled, prepare a privately connected publishing machine or runner as described in the [Full Deployment Guide](./full-deployment-guide.md#private-only-logic-app-publishing).
+
 #### 4. **Feature Flags**
 Enable or disable specific capabilities:
 ```bicep

--- a/guides/post-deployment-guide.md
+++ b/guides/post-deployment-guide.md
@@ -29,6 +29,7 @@ Work top-to-bottom. Steps 1–2 are **required** to serve traffic; the rest are 
 - [ ] **4. Usage reporting activated** *(recommended)* — Power BI dashboard connected to Cosmos DB → [Power BI Dashboard](./power-bi-dashboard.md)
 - [ ] **5. Multi-region linked** *(if global)* — Cosmos DB multi-write across regions → [Cosmos Global Sync](../bicep/infra/citadel-cosmos-global-multi-master-sync/README.md)
 - [ ] **6. Gateway upgraded** *(as releases ship)* — new policies/APIs/backends applied in place → [APIM Gateway Upgrade](../bicep/infra/apim-gateway-upgrade/README.md)
+- [ ] **Logic App private connectivity verified** *(when enabled)* - website/SCM DNS, workflow publishing, public access restrictions, and ingestion health checked using the [private connectivity checklist](#logic-app-private-connectivity-checks).
 
 > All submodules use versioned Bicep parameter files (`.bicepparam`) and are DevOps/CI-CD friendly. Keep customized copies under source control, separate from the accelerator's default files.
 
@@ -153,6 +154,21 @@ curl https://<your-apim-gateway-host>/version/backend-contract
 ---
 
 ## 7. Validation
+
+### Logic App private connectivity checks
+
+When `logicAppUsePrivateEndpoint = true`, complete these checks after provisioning and workflow publishing. The flags default to `false` / `true` for endpoint creation / public access; see the [parameter reference](./parameters-usage-guide.md#logic-app-private-access) and [publishing prerequisites](./full-deployment-guide.md#private-only-logic-app-publishing).
+
+- [ ] The Logic App private endpoint connection is **Approved**, targets the `sites` subresource, and uses the private-endpoint subnet rather than the delegated outbound integration subnet.
+- [ ] From the publishing runner and administration network, both `<app>.azurewebsites.net` and `<app>.scm.azurewebsites.net` resolve to the endpoint's private IP and are reachable over HTTPS. Confirm the `privatelink.azurewebsites.net` zone group and both records, plus any required links or forwarding.
+- [ ] Authenticated workflow publishing succeeds through private SCM, and the expected workflows are present and enabled. Infrastructure deployment success alone is not sufficient.
+- [ ] For private-only mode, the site's `publicNetworkAccess` is `Disabled`. From a client without private connectivity, confirm website and SCM access are blocked by the public-network restriction; an authentication error or missing-route response alone is not proof. Skip this rejection check when public access is intentionally enabled for staged verification.
+- [ ] Expected Event Hub and scheduled ingestion workflows run successfully, fresh usage records reach Cosmos DB, and Event Hub backlog is not accumulating unexpectedly.
+- [ ] Storage access and monitoring connections remain healthy, logs continue to arrive, and there are no new dependency connectivity errors. Confirm other services' access settings and outbound integration remain unchanged.
+
+**Existing-app maintenance:** Do not rerun the main or resource-group accelerator templates to convert an existing hub. Plan a separately approved, narrowly scoped networking change; the gateway-upgrade supporting-services templates do not expose these flags. Changes can restart the app or delay ingestion, so validate recovery rather than assuming zero disruption. In an incremental ARM deployment, setting `logicAppUsePrivateEndpoint = false` does not delete an existing endpoint; removal requires a separate reviewed operation. Any temporary restoration of public access requires owner and policy approval.
+
+### Governance validation
 
 Use the validation notebooks under the [`/validation`](../validation/) folder to verify each step:
 

--- a/guides/quick-deployment-guide.md
+++ b/guides/quick-deployment-guide.md
@@ -17,6 +17,8 @@ This guide provides the fastest path to deploying AI Citadel Governance Hub for 
 
 > 💡 **Tip:** You can use [Azure Cloud Shell](https://shell.azure.com) which has all tools pre-installed.
 
+> **Private-only Logic App:** Ordinary Cloud Shell and public hosted CI runners should not be assumed to reach private SCM. Workflow publishing requires a privately connected machine with suitable DNS; see [private publishing prerequisites](./full-deployment-guide.md#private-only-logic-app-publishing).
+
 ---
 
 ## 🎯 Deployment Options
@@ -65,6 +67,8 @@ This will:
 - ✅ Deploy 2 AI Foundry instances with sample models
 - ✅ Enable all core features (PII detection, content safety, API Center)
 
+The Logic App retains public access by default and does not create its own private endpoint unless explicitly enabled. Other services keep their existing defaults.
+
 **Expected deployment time:** 30-45 minutes
 
 ---
@@ -95,8 +99,12 @@ azd up
 | `COSMOS_DB_RUS` | `400` | Cosmos DB throughput |
 | `EVENTHUB_CAPACITY` | `1` | Event Hub capacity units |
 | `ENABLE_API_CENTER` | `true` | Enable API Center registry |
+| `LOGIC_APP_USE_PRIVATE_ENDPOINT` | `false` | Create a Logic App inbound private endpoint |
+| `LOGIC_APP_PUBLIC_NETWORK_ACCESS` | `true` | Allow public website and SCM/Kudu access |
 
 For full list of variables, see [/bicep/infra/main.bicepparam](../bicep/infra/main.bicepparam).
+
+For a private-only initial deployment, set `LOGIC_APP_USE_PRIVATE_ENDPOINT` to `true` and `LOGIC_APP_PUBLIC_NETWORK_ACCESS` to `false`, and run workflow publishing from a privately connected machine. For existing VNets, also configure the existing DNS zone and links or forwarding. See the [Logic App parameter reference](./parameters-usage-guide.md#logic-app-private-access) for DNS and optional endpoint-name overrides, and the [network guide](./network-approach.md#logic-app-private-connectivity) for setup details.
 
 ---
 
@@ -144,6 +152,8 @@ az deployment group create \
 ```
 
 Deploy the Logic App workflow separately after the infrastructure deployment completes.
+
+If Logic App public access is disabled, publish from a machine that meets the [private SCM prerequisites](./full-deployment-guide.md#private-only-logic-app-publishing), then complete the [private connectivity checks](./post-deployment-guide.md#logic-app-private-connectivity-checks).
 
 ---
 


### PR DESCRIPTION
## Summary

Enables deployment of the usage-ingestion Logic App with a private endpoint and public network access disabled. The feature is opt-in: existing defaults remain unchanged, and other components retain their current configuration.

## Commit 1: Implementation

`3b2b689` — `feat: add private endpoint support for usage ingestion Logic App`

Updates five infrastructure files to:
- Add independent `logicAppUsePrivateEndpoint` and `logicAppPublicNetworkAccess` flags, defaulting to `false` and `true`.
- Configure public access at the site resource level, replacing the hardcoded child configuration.
- Reuse the shared private-endpoint module with the `sites` subresource for both website and SCM/Kudu connectivity.
- Support an optional endpoint name override through `logicAppPrivateEndpointName`.
- Support existing DNS zones through `existingPrivateDnsZones.logicApp` or `dnsZoneRG`/`dnsSubscriptionId`, with automatic local zone creation and linking for new VNets when no existing zone is supplied.
- Expose the configuration through both subscription-scope and resource-group-scope parameter entry points.

Private-only configuration:

```dotenv
LOGIC_APP_USE_PRIVATE_ENDPOINT="true"
LOGIC_APP_PUBLIC_NETWORK_ACCESS="false"
```

Optional overrides: `LOGIC_APP_PE_NAME` and `EXISTING_DNS_ZONE_LOGIC_APP`.

## Commit 2: Documentation

`2f777c0` — `docs: document private-only Logic App deployment`

Updates the README and five guides to:
- Document parameter mappings, defaults, and all four flag combinations.
- Explain the single website/SCM endpoint, DNS selection, and ownership of links or forwarding.
- Document private-network prerequisites for workflow publishing, including limitations of ordinary Cloud Shell and public hosted runners.
- Correct blanket default-private claims and update private deployment examples.
- Add connectivity, publishing, ingestion-health, and existing-app maintenance checks.

## Compatibility and Scope

- Workflow definitions, runtime versions, outbound VNet integration, routing, identities, RBAC, and other services' access settings are unchanged.
- Changes apply to the main initial-deployment templates, not the separate gateway-upgrade supporting-services templates.
- Existing-app conversion requires a separately reviewed, narrowly scoped change; zero disruption is not guaranteed.
- DNS readiness and flag combinations are not enforced by custom guardrails. Existing-VNet deployments without a DNS input skip zone-group creation.
- Disabling endpoint creation does not delete an existing endpoint during incremental deployment.

## Validation

Completed during implementation:
- [x] Bicep compilation passed for the Logic App module, main template, and both parameter files; compiler warnings remain.
- [x] Generated ARM assertions passed for defaults, forwarding, public-access control, endpoint conditions, and DNS wiring.
- [x] All six updated Markdown documents rendered successfully; 20 new relative links and anchors resolved.
- [x] Parameter documentation matched both entry points; editor diagnostics and whitespace checks passed.
- [x] Live deployment in a target environment.
- [x] Private DNS resolution and website/SCM connectivity verification.
- [x] Authenticated workflow publishing through private SCM.
